### PR TITLE
Set new BaseFeeLimit in TxPool on postForkBlock

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -524,14 +524,6 @@ func (pool *TxPool) SetMinFee(minFee *big.Int) {
 	pool.minimumFee = minFee
 }
 
-func (pool *TxPool) SetFixedFee(fixedFee *big.Int) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
-
-	pool.minimumFee = fixedFee
-	pool.fixedBaseFee = true
-}
-
 // Nonce returns the next nonce of an account, with all transactions executable
 // by the pool already applied on top.
 func (pool *TxPool) Nonce(addr common.Address) uint64 {
@@ -1413,7 +1405,10 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	timestamp := new(big.Int).SetUint64(newHead.Time)
 	pool.eip2718 = pool.chainconfig.IsApricotPhase2(timestamp)
 	pool.eip1559 = pool.chainconfig.IsApricotPhase3(timestamp)
-	pool.fixedBaseFee = pool.chainconfig.IsSunrisePhase0(timestamp)
+	if pool.chainconfig.IsSunrisePhase0(timestamp) {
+		pool.fixedBaseFee = true
+		pool.minimumFee = new(big.Int).SetUint64(params.SunrisePhase0BaseFee)
+	}
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -122,6 +122,10 @@ type DeferedChecks struct {
 	deferedChecks map[ids.ID]*Block
 }
 
+func (d *DeferedChecks) Count() int {
+	return len(d.deferedChecks)
+}
+
 func (d *DeferedChecks) Push(id ids.ID, b *Block) {
 	d.deferedChecks[id] = b
 }

--- a/plugin/evm/gasprice_update.go
+++ b/plugin/evm/gasprice_update.go
@@ -33,7 +33,6 @@ type gasPriceUpdater struct {
 type gasPriceSetter interface {
 	SetGasPrice(price *big.Int)
 	SetMinFee(price *big.Int)
-	SetFixedFee(price *big.Int)
 }
 
 // handleGasPriceUpdates creates and runs an instance of
@@ -68,8 +67,7 @@ func (gpu *gasPriceUpdater) start() {
 	if disabled := gpu.handleUpdate(gpu.setter.SetMinFee, gpu.chainConfig.ApricotPhase4BlockTimestamp, big.NewInt(params.ApricotPhase4MinBaseFee)); disabled {
 		return
 	}
-	// Updates to the minimum gas price as of SunrisePhase0 if it's already in effect or starts a goroutine to enable it at the correct time
-	gpu.handleUpdate(gpu.setter.SetFixedFee, gpu.chainConfig.SunrisePhase0BlockTimestamp, big.NewInt(int64(params.SunrisePhase0BaseFee)))
+	// SunrisePhase0 GasLimit starts with the first postForkBlock. We Handle the update in TxPool (reset)
 }
 
 // handleUpdate handles calling update(price) at the appropriate time based on

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -835,6 +835,9 @@ func (vm *VM) SetState(state snow.State) error {
 		vm.bootstrapped = false
 		return vm.fx.Bootstrapping()
 	case snow.NormalOp:
+		if num := vm.DeferedChecks.Count(); num > 0 {
+			return fmt.Errorf("%d blocks has been verified", num)
+		}
 		vm.bootstrapped = true
 		return vm.fx.Bootstrapped()
 	default:


### PR DESCRIPTION
## Apply Fees in TXPool on postForkBlock
The core implemenation triggers fee changes in TxPool based on timestamp (gasFeeUpdater)
Because our SunrisePhases start with the first block >= Phase activation time, it must be adapted in TxPool.

* TxPool reset() is called on StartUp and everytime a new Block was inserted.
* We use block.header.timestamp for evaluating if Sunrise Phase is active in scope of the TXPool

### Why?
On testnet we have been block wise before SunrisePhase0, but time-wise behind.
TxPool had already the new baseFeeLmit applied (due to gasUpdater), but the baseFee returned from GetGasPrice still returned the provious limit. This lead to "underpriced" errors using the camino wallet (SunrisePhase0 increases GasLimit from 25 -> 50 GWEI)

## Fix SunrisePhase0 Block SyntacticVerify if parent block is not available
Without this PR a new full sync is not working, reason is that we use block parent to get the rules (see above).
During sync the parent is not available, so we have to check the post-fork block at the time the parent of it arrives.