### PR TITLE
TECH-162: added sunrise phase0 unit test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,62 +52,62 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.17' ]
-        os: [ macos-11.0, ubuntu-18.04 ]
+        go: ['1.17']
+        os: [macos-11.0, ubuntu-18.04]
     steps:
-      - uses: actions/checkout@v3
-      - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.inputs.caminogoRepo }}
-          ref: ${{ github.event.inputs.caminogoBranch }}
-          path: caminogo
-          token: ${{ secrets.CAMINO_PAT }}
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-      - name: change caminogo dep
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          go mod edit -replace github.com/chain4travel/caminogo=./caminogo
-          go mod tidy
-      - run: go mod download
-        shell: bash
-      - run: ./scripts/build.sh evm
-        shell: bash
-      - run: ./scripts/test.sh
-        shell: bash
-      - run: ./scripts/coverage.sh
-        shell: bash
+    - uses: actions/checkout@v3
+    - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.caminogoRepo }}
+        ref: ${{ github.event.inputs.caminogoBranch }}
+        path: caminogo
+        token: ${{ secrets.CAMINO_PAT }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    - name: change caminogo dep
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        go mod edit -replace github.com/chain4travel/caminogo=./caminogo
+        go mod tidy
+    - run: go mod download
+      shell: bash
+    - run: ./scripts/build.sh evm
+      shell: bash
+    - run: ./scripts/test.sh
+      shell: bash
+    - run: ./scripts/coverage.sh
+      shell: bash
   test-race:
     name: Golang Unit Tests Race Detection v${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.17' ]
-        os: [ ubuntu-20.04 ]
+        go: ['1.17']
+        os: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
-      - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.inputs.caminogoRepo }}
-          ref: ${{ github.event.inputs.caminogoBranch }}
-          path: caminogo
-          token: ${{ secrets.CAMINO_PAT }}
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-      - name: change caminogo dep
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          go mod edit -replace github.com/chain4travel/caminogo=./caminogo
-          go mod tidy
-      - run: go mod download
-        shell: bash
-      - run: ./scripts/build.sh evm
-        shell: bash
-      - run: ./scripts/test.sh -race
-        shell: bash
+    - uses: actions/checkout@v3
+    - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.caminogoRepo }}
+        ref: ${{ github.event.inputs.caminogoBranch }}
+        path: caminogo
+        token: ${{ secrets.CAMINO_PAT }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    - name: change caminogo dep
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        go mod edit -replace github.com/chain4travel/caminogo=./caminogo
+        go mod tidy
+    - run: go mod download
+      shell: bash
+    - run: ./scripts/build.sh evm
+      shell: bash
+    - run: ./scripts/test.sh -race
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,62 +52,62 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.17']
-        os: [macos-11.0, ubuntu-18.04]
+        go: [ '1.17' ]
+        os: [ macos-11.0, ubuntu-18.04 ]
     steps:
-    - uses: actions/checkout@v3
-    - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ github.event.inputs.caminogoRepo }}
-        ref: ${{ github.event.inputs.caminogoBranch }}
-        path: caminogo
-        token: ${{ secrets.CAMINO_PAT }}
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - name: change caminogo dep
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        go mod edit -replace github.com/chain4travel/caminogo=./caminogo
-        go mod tidy
-    - run: go mod download
-      shell: bash
-    - run: ./scripts/build.sh evm
-      shell: bash
-    - run: ./scripts/test.sh
-      shell: bash
-    - run: ./scripts/coverage.sh
-      shell: bash
+      - uses: actions/checkout@v3
+      - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.caminogoRepo }}
+          ref: ${{ github.event.inputs.caminogoBranch }}
+          path: caminogo
+          token: ${{ secrets.CAMINO_PAT }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: change caminogo dep
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          go mod edit -replace github.com/chain4travel/caminogo=./caminogo
+          go mod tidy
+      - run: go mod download
+        shell: bash
+      - run: ./scripts/build.sh evm
+        shell: bash
+      - run: ./scripts/test.sh
+        shell: bash
+      - run: ./scripts/coverage.sh
+        shell: bash
   test-race:
     name: Golang Unit Tests Race Detection v${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.17']
-        os: [ubuntu-20.04]
+        go: [ '1.17' ]
+        os: [ ubuntu-20.04 ]
     steps:
-    - uses: actions/checkout@v3
-    - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ github.event.inputs.caminogoRepo }}
-        ref: ${{ github.event.inputs.caminogoBranch }}
-        path: caminogo
-        token: ${{ secrets.CAMINO_PAT }}
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - name: change caminogo dep
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        go mod edit -replace github.com/chain4travel/caminogo=./caminogo
-        go mod tidy
-    - run: go mod download
-      shell: bash
-    - run: ./scripts/build.sh evm
-      shell: bash
-    - run: ./scripts/test.sh -race
-      shell: bash
+      - uses: actions/checkout@v3
+      - name: check out ${{ github.event.inputs.caminogoRepo }} ${{ github.event.inputs.caminogoBranch }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.caminogoRepo }}
+          ref: ${{ github.event.inputs.caminogoBranch }}
+          path: caminogo
+          token: ${{ secrets.CAMINO_PAT }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: change caminogo dep
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          go mod edit -replace github.com/chain4travel/caminogo=./caminogo
+          go mod tidy
+      - run: go mod download
+        shell: bash
+      - run: ./scripts/build.sh evm
+        shell: bash
+      - run: ./scripts/test.sh -race
+        shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches-ignore: ["*"]
+    branches-ignore: ["**"]
 
 jobs:
   e2e:

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -51,6 +51,8 @@ var (
 	errNilTxID       = errors.New("nil transaction ID")
 
 	initialBaseFee = big.NewInt(params.ApricotPhase3InitialBaseFee)
+
+	sunriseBaseFee = big.NewInt(int64(params.SunrisePhase0BaseFee))
 )
 
 // SnowmanAPI introduces snowman specific functionality to the evm

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/chain4travel/caminoethvm/trie"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
@@ -76,6 +77,9 @@ var (
 	testAvaxAssetID  = ids.ID{1, 2, 3}
 	username         = "Johns"
 	password         = "CjasdjhiPeirbSenfeI13" // #nosec G101
+
+	apricotPhase5BlockTimestamp = big.NewInt(time.Now().Add(time.Minute * -20).Unix())
+	sunrisePhase0BlockTimestamp = big.NewInt(time.Now().Add(time.Minute * -10).Unix())
 	// Use chainId: 43111, so that it does not overlap with any Avalanche ChainIDs, which may have their
 	// config overridden in vm.Initialize.
 	genesisJSONApricotPhase0 = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
@@ -84,6 +88,16 @@ var (
 	genesisJSONApricotPhase3 = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
 	genesisJSONApricotPhase4 = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0,\"apricotPhase4BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
 	genesisJSONApricotPhase5 = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0,\"apricotPhase4BlockTimestamp\":0, \"apricotPhase5BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
+
+	timestamps = "\"apricotPhase1BlockTimestamp\": 0," +
+		"\"apricotPhase2BlockTimestamp\": 0," +
+		"\"apricotPhase3BlockTimestamp\": 0, " +
+		"\"apricotPhase4BlockTimestamp\": 0, " +
+		"\"apricotPhase5BlockTimestamp\": " + fmt.Sprint(apricotPhase5BlockTimestamp) + ", " +
+		" \"sunrisePhase0BlockTimestamp\": " + fmt.Sprint(sunrisePhase0BlockTimestamp)
+
+	genesisJSONSunrisePhase0WithCustomTimestamps = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0," + timestamps + "},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
+	genesisJSONSunrisePhase0                     = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0,\"apricotPhase4BlockTimestamp\":0, \"apricotPhase5BlockTimestamp\":0,\"sunrisePhase0BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
 
 	apricotRulesPhase0 = params.Rules{}
 	apricotRulesPhase1 = params.Rules{IsApricotPhase1: true}
@@ -174,7 +188,8 @@ func setupGenesis(t *testing.T,
 	manager.Manager,
 	[]byte,
 	chan engCommon.Message,
-	*atomic.Memory) {
+	*atomic.Memory,
+) {
 	genesisBytes := BuildGenesisTest(t, genesisJSON)
 	ctx := NewContext()
 
@@ -209,7 +224,8 @@ func GenesisVM(t *testing.T,
 ) (chan engCommon.Message,
 	*VM, manager.Manager,
 	*atomic.Memory,
-	*engCommon.SenderTest) {
+	*engCommon.SenderTest,
+) {
 	vm := &VM{}
 	ctx, dbManager, genesisBytes, issuer, m := setupGenesis(t, genesisJSON)
 	appSender := &engCommon.SenderTest{T: t}
@@ -2968,6 +2984,242 @@ func TestReissueAtomicTx(t *testing.T) {
 	} else if height != blkB.Height() {
 		t.Fatalf("Expected indexed height of import tx to be %d, but found %d", blkB.Height(), height)
 	}
+}
+
+// Regression test to ensure we can build blocks if we are starting with the
+// Apricot Phase 5 ruleset AND Sunrise Phase 0 in genesis.
+func TestSunrisePhase0AndApricotPhase5Block(t *testing.T) {
+	importAmount := uint64(1_000_000_000)
+	issuer, vm, _, _, _ := GenesisVMWithUTXOs(t, true, genesisJSONSunrisePhase0WithCustomTimestamps, "{\"pruning-enabled\":true}", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+		testShortIDAddrs[1]: importAmount,
+	})
+
+	defer func() {
+		if err := vm.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	newTxPoolHeadChan1 := make(chan core.NewTxPoolReorgEvent, 1)
+	vm.chain.GetTxPool().SubscribeNewReorgEvent(newTxPoolHeadChan1)
+
+	// set vm's time 1min after apricot phase 5
+	// vm.clock.Set(apricotPhase5Timestamp.Add(time.Minute * 1))
+	vm.clock.Set(time.Unix(apricotPhase5BlockTimestamp.Int64(), 0).Add(time.Minute * 1))
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[1], big.NewInt(0).Mul(initialBaseFee, big.NewInt(10)), []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vm.issueTx(importTx, true /*=local*/); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer
+
+	// Block A should be validated with apricot rules
+	blkA, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build block with import transaction: %s", err)
+	}
+	if err := blkA.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM: %s", err)
+	}
+	if status := blkA.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	// set vm's time 1min after sunrise phase 0
+	// vm.clock.Set(apricotPhase5Timestamp.Add(time.Minute * 21))
+	vm.clock.Set(time.Unix(sunrisePhase0BlockTimestamp.Int64(), 0).Add(time.Minute))
+
+	importTx2, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[2], sunriseBaseFee, []*crypto.PrivateKeySECP256K1R{testKeys[1]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vm.issueTx(importTx2, true /*=local*/); err != nil {
+		t.Fatal(err)
+	}
+	<-issuer
+
+	// Block B is the first block to be built after sunrise0 timestamp should be validated with apricot rules
+	blkB, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build block with import transaction: %s", err)
+	}
+	if err := blkB.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM: %s", err)
+	}
+	if status := blkB.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	importTx3, err := vm.newExportTx(vm.ctx.AVAXAssetID, uint64(50000), vm.ctx.XChainID, testShortIDAddrs[0], big.NewInt(0).Mul(sunriseBaseFee, big.NewInt(100)), []*crypto.PrivateKeySECP256K1R{testKeys[1]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vm.issueTx(importTx3, true /*=local*/); err != nil {
+		t.Fatal(err)
+	}
+	<-issuer
+
+	// Block C is the second block to be built after sunrise0 timestamp should be validated with apricot rules
+	blkC, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build block with import transaction: %s", err)
+	}
+	if err := blkC.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM: %s", err)
+	}
+	if status := blkC.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+	// assertions
+	blkAEthBlockA := blkA.(*chain.BlockWrapper).Block.(*Block).ethBlock
+	blkAEthBlockB := blkB.(*chain.BlockWrapper).Block.(*Block).ethBlock
+	blkAEthBlockC := blkC.(*chain.BlockWrapper).Block.(*Block).ethBlock
+	assert.Equal(t, initialBaseFee, blkAEthBlockA.Header().BaseFee) // that's alright, see dynamic_fees.go#CalcBaseFee
+	assert.Equal(t, params.ApricotPhase4MinBaseFee, blkAEthBlockB.Header().BaseFee.Int64())
+	assert.Equal(t, sunriseBaseFee, blkAEthBlockC.Header().BaseFee)
+}
+
+// Regression test to ensure a normally created Sunrise Phase 0 Block A will be validated,
+// a Sunrise Phase 0 Block B with empty body and Block A as a parent will not be validated and
+// a Sunrise Phase 0 Block C with a missing parent will be syntactically validated (but not verified due to missing parent)
+func TestSunrisePhase0OrphanBlock(t *testing.T) {
+	importAmount := uint64(1000000000)
+	issuer, vm, _, _, _ := GenesisVMWithUTXOs(t, true, genesisJSONSunrisePhase0, "", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+	})
+
+	defer func() {
+		if err := vm.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	newTxPoolHeadChan1 := make(chan core.NewTxPoolReorgEvent, 1)
+	vm.chain.GetTxPool().SubscribeNewReorgEvent(newTxPoolHeadChan1)
+
+	key := testKeys[0].ToECDSA()
+	address := testEthAddrs[0]
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, address, sunriseBaseFee, []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm.issueTx(importTx, true /*=local*/); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer
+
+	// Block A should be validated normally
+	blkA, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build block with import transaction: %s", err)
+	}
+
+	if err := blkA.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM: %s", err)
+	}
+
+	if status := blkA.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	if err := vm.SetPreference(blkA.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	blkAEthBlock := blkA.(*chain.BlockWrapper).Block.(*Block).ethBlock
+
+	// Assertion for BaseFee
+	assert.EqualValues(t, blkAEthBlock.BaseFee(), sunriseBaseFee, "Block's Base fee should be SunrisePhase0's Base Fee")
+
+	// Create list of 10 successive transactions to build block B on vm
+	txs := make([]*types.Transaction, 10)
+	for i := 0; i < 10; i++ {
+		tx := types.NewTransaction(uint64(i), address, big.NewInt(10), 21000, big.NewInt(params.LaunchMinGasPrice), nil)
+		signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm.chainID), key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txs[i] = signedTx
+	}
+
+	// Add the remote transactions, build the block, and set VM's preference
+	// for block B
+	errs := vm.chain.AddRemoteTxsSync(txs)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Failed to add transaction to VM at index %d: %s", i, err)
+		}
+	}
+
+	<-issuer
+
+	// Manually created Eth Block with a manually created header
+	ethBlkB := types.NewBlock(
+		&types.Header{
+			ParentHash:  blkAEthBlock.Hash(),
+			UncleHash:   types.EmptyUncleHash,
+			TxHash:      types.EmptyRootHash,
+			ReceiptHash: types.EmptyRootHash,
+			Difficulty:  math.BigPow(1, 1),
+			Number:      math.BigPow(2, 9),
+			GasLimit:    0,
+			GasUsed:     0,
+			Time:        9876543,
+			Extra:       []byte("coolest block on chain"),
+		},
+		nil,
+		nil,
+		nil,
+		new(trie.Trie),
+		nil,
+		false,
+	)
+
+	blkB := &Block{
+		vm:       vm,
+		ethBlock: ethBlkB,
+		id:       ids.ID(ethBlkB.Hash()),
+	}
+
+	// Block B is empty created but with a valid parent therefore, its verification should return an error
+	assert.Error(t, blkB.Verify())
+
+	// Manually created Eth Block with a manually created header
+	emptyEthBlock := types.NewBlock(
+		&types.Header{
+			Difficulty: math.BigPow(11, 11),
+			Number:     math.BigPow(2, 9),
+			GasLimit:   12345678,
+			GasUsed:    1476322,
+			Time:       9876543,
+			Extra:      []byte("emptiest block on chain"),
+		},
+		nil,
+		nil,
+		nil,
+		new(trie.Trie),
+		nil,
+		false,
+	)
+	// Manually created block with a dummy parent
+	emptyBlock := &Block{
+		vm:       vm,
+		ethBlock: emptyEthBlock,
+		id:       ids.ID(emptyEthBlock.Hash()),
+	}
+
+	// emptyBlock does not have a valid parent therefore, it shouldn't return an error from Syntactic Verification.
+	// It should return a "rejected parent" error though, from Atomic TXs Verification where it's being ensured
+	// that the parent was verified and inserted correctly.
+	assert.Error(t, emptyBlock.Verify())
 }
 
 func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -72,7 +72,7 @@ func (vs *ValidationMessages) Info(msg string) {
 	vs.Messages = append(vs.Messages, ValidationInfo{INFO, msg})
 }
 
-/// getWarnings returns an error with all messages of type WARN of above, or nil if no warnings were present
+// getWarnings returns an error with all messages of type WARN of above, or nil if no warnings were present
 func (v *ValidationMessages) GetWarnings() error {
 	var messages []string
 	for _, msg := range v.Messages {


### PR DESCRIPTION
**Purpose**
This PR is intended for testing Sunrise0 orphan blocks as well as appropriate rule application for each block verification based on the phase the blockchain is running in. The tests include the following scenario:
 - Generation of three blocks (A, B and C)

   - A is built before sunrise phase and apricotPhase5 rules are applied
   - B is the first block built after the sunrisePhase0 timestamp and again apricotPhase5 rules are applied
   - C is the second block built after the sunrisePhase0 timestamp and sunrisePhase0 rules are applied

**Changes**
In addition to the sunrise related changes, the following files have also been modified:

- ci.yaml : The golangci-lint version has been changed from latest to v1.47.0 because more recent versions mess with the static checks and require a great number of adjustments mainly to comments.
We could use an even older version such as v1.43.0 which is the version set in the caminogo repo (see scripts/lint.sh)
- e2e.yaml : the * wildcard in branches-ignore was not accounting for branches with slashes in their names. Thus, e2e tests were triggered initially when the branch was named feature/.... (see also https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)

