### PR TITLE
Fix Readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.CAMINO_PAT }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.17.9
       - name: change caminogo dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -43,9 +43,10 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.47.0
           working-directory: .
           args: --timeout 3m
+          skip-go-installation: true
   test:
     name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The C-Chain is compatible with almost all Ethereum tooling, including [Remix](ht
 
 As a network composed of multiple blockchains, Camino uses *atomic transactions* to move assets between chains. CaminoEthVm modifies the Ethereum block format by adding an *ExtraData* field, which contains the atomic transactions.
 
-### Avalanche Native Tokens (ANTs)
+### Camino Native Tokens (CNTs)
 
 The C-Chain supports Camino Native Tokens, which are created on the X-Chain using precompiled contracts. These precompiled contracts *nativeAssetCall* and *nativeAssetBalance* support the same interface for CNTs as *CALL* and *BALANCE* do for CAM with the added parameter of *assetID* to specify the asset.
 


### PR DESCRIPTION
1.) Readme Fix of CaminoNativeTokens
2.) Stick CI-linter version to v1.47.0, because versions >= 1.49 are build with golang 1.19 and introduce new formatting rules
