### PR TITLE
jax/linter test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.47.3
+          version: latest
+          skip-go-installation: true
           working-directory: .
           args: --timeout 3m
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.47.3
           working-directory: .
           args: --timeout 3m
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           version: latest
           skip-go-installation: true
+          skip-pkg-cache: true
+          skip-build-cache: true
           working-directory: .
           args: --timeout 3m
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,15 +12,13 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - goconst
-    - goimports
+    - gofmt
     - gosimple
     - govet
     - ineffassign
     - misspell
     - unconvert
-    - varcheck
 
 linters-settings:
   gofmt:
@@ -31,18 +29,6 @@ linters-settings:
 
 issues:
   exclude-rules:
-    - path: crypto/blake2b/
-      linters:
-        - deadcode
-    - path: crypto/bn256/cloudflare
-      linters:
-        - deadcode
-    - path: p2p/discv5/
-      linters:
-        - deadcode
     - path: core/vm/instructions_test.go
       linters:
         - goconst
-    - path: cmd/faucet/
-      linters:
-        - deadcode

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The C-Chain is compatible with almost all Ethereum tooling, including [Remix](ht
 
 As a network composed of multiple blockchains, Camino uses *atomic transactions* to move assets between chains. CaminoEthVm modifies the Ethereum block format by adding an *ExtraData* field, which contains the atomic transactions.
 
-### Avalanche Native Tokens (ANTs)
+### Camino Native Tokens (CNTs)
 
 The C-Chain supports Camino Native Tokens, which are created on the X-Chain using precompiled contracts. These precompiled contracts *nativeAssetCall* and *nativeAssetBalance* support the same interface for CNTs as *CALL* and *BALANCE* do for CAM with the added parameter of *assetID* to specify the asset.
 

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -255,10 +255,12 @@ func (t *testHelper) Generate() (common.Hash, *diskLayer) {
 //   - miss in the beginning
 //   - miss in the middle
 //   - miss in the end
+//
 // - the contract(non-empty storage) has wrong storage slots
 //   - wrong slots in the beginning
 //   - wrong slots in the middle
 //   - wrong slots in the end
+//
 // - the contract(non-empty storage) has extra storage slots
 //   - extra slots in the beginning
 //   - extra slots in the middle

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -390,11 +390,13 @@ func (t *Tree) verifyIntegrity(base *diskLayer, waitBuild bool) error {
 // Note: a blockHash is used instead of a state root so that the exact state
 // transition between the two states is well defined. This is intended to
 // prevent the following edge case
-//    A
-//   /  \
-//  B    C
-//       |
-//       D
+//
+//	  A
+//	 /  \
+//	B    C
+//	     |
+//	     D
+//
 // In this scenario, it's possible For (A, B) and (A, C, D) to be two
 // different paths to the resulting state. We use block hashes and parent
 // block hashes to ensure that the exact path through which we flatten

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -72,7 +72,7 @@ func (vs *ValidationMessages) Info(msg string) {
 	vs.Messages = append(vs.Messages, ValidationInfo{INFO, msg})
 }
 
-/// getWarnings returns an error with all messages of type WARN of above, or nil if no warnings were present
+// / getWarnings returns an error with all messages of type WARN of above, or nil if no warnings were present
 func (v *ValidationMessages) GetWarnings() error {
 	var messages []string
 	for _, msg := range v.Messages {


### PR DESCRIPTION
- Fix Readme
- Linter: Remove deprecated / buggy goimport/deadcode/varcheck, add gofmt
- format everything
