### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_newspace = true
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4
+
+[*.{sol,yul}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
I had the problem of sharing diffs with @peak3d due to inconsistent whitespaces. That took me longer than I want to admit to figure out and to not have this happen again im introducing this file which whill help sync the way we write code across editors.

For more info please have a look here: https://editorconfig.org/
If this gets accepted please use a plugin or tool that respects the rules in this file.
