### PR TITLE
Admin interface + implementation for setting gasFees via TX

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -30,6 +40,7 @@ package consensus
 import (
 	"math/big"
 
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
@@ -53,6 +64,9 @@ type ChainHeaderReader interface {
 
 	// GetHeaderByHash retrieves a block header from the database by its hash.
 	GetHeaderByHash(hash common.Hash) *types.Header
+
+	// Admincontroler retrieves an interface to smart contract controlled state
+	AdminController() admin.AdminController
 }
 
 // ChainReader defines a small collection of methods needed to access the local

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/coreth/consensus"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
@@ -95,7 +96,7 @@ func NewFullFaker() *DummyEngine {
 	}
 }
 
-func (self *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header *types.Header, parent *types.Header) error {
+func (self *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, ctrl admin.AdminController, header *types.Header, parent *types.Header) error {
 	timestamp := new(big.Int).SetUint64(header.Time)
 
 	// Verify that the gas limit is <= 2^63-1
@@ -131,7 +132,7 @@ func (self *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, heade
 	} else {
 		// Verify baseFee and rollupWindow encoding as part of header verification
 		// starting in AP3
-		expectedRollupWindowBytes, expectedBaseFee, err := CalcBaseFee(config, parent, header.Time)
+		expectedRollupWindowBytes, expectedBaseFee, err := CalcBaseFee(config, ctrl, parent, header.Time)
 		if err != nil {
 			return fmt.Errorf("failed to calculate base fee: %w", err)
 		}
@@ -219,7 +220,7 @@ func (self *DummyEngine) verifyHeader(chain consensus.ChainHeaderReader, header 
 		}
 	}
 	// Ensure gas-related header fields are correct
-	if err := self.verifyHeaderGasFields(config, header, parent); err != nil {
+	if err := self.verifyHeaderGasFields(config, chain.AdminController(), header, parent); err != nil {
 		return err
 	}
 	// Verify the header's timestamp

--- a/consensus/dummy/dynamic_fees_test.go
+++ b/consensus/dummy/dynamic_fees_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -203,7 +213,7 @@ func testDynamicFeesStaysWithinRange(t *testing.T, test test) {
 	}
 
 	for index, block := range blocks[1:] {
-		nextExtraData, nextBaseFee, err := CalcBaseFee(params.TestApricotPhase3Config, header, block.timestamp)
+		nextExtraData, nextBaseFee, err := CalcBaseFee(params.TestApricotPhase3Config, nil, header, block.timestamp)
 		if err != nil {
 			t.Fatalf("Failed to calculate base fee at index %d: %s", index, err)
 		}
@@ -408,7 +418,7 @@ func TestCalcBaseFeeAP4(t *testing.T) {
 
 	for index, event := range events {
 		block := event.block
-		nextExtraData, nextBaseFee, err := CalcBaseFee(params.TestApricotPhase4Config, header, block.timestamp)
+		nextExtraData, nextBaseFee, err := CalcBaseFee(params.TestApricotPhase4Config, nil, header, block.timestamp)
 		assert.NoError(t, err)
 		log.Info("Update", "baseFee", nextBaseFee)
 		header = &types.Header{
@@ -419,7 +429,7 @@ func TestCalcBaseFeeAP4(t *testing.T) {
 			Extra:   nextExtraData,
 		}
 
-		nextExtraData, nextBaseFee, err = CalcBaseFee(params.TestApricotPhase4Config, extDataHeader, block.timestamp)
+		nextExtraData, nextBaseFee, err = CalcBaseFee(params.TestApricotPhase4Config, nil, extDataHeader, block.timestamp)
 		assert.NoError(t, err)
 		log.Info("Update", "baseFee (w/extData)", nextBaseFee)
 		extDataHeader = &types.Header{

--- a/contracts/camino_smart_contracts_test.go
+++ b/contracts/camino_smart_contracts_test.go
@@ -1,31 +1,32 @@
 // Copyright (C) 2022, Chain4Travel AG. All rights reserved.
-//
-// This file is a derived work, based on ava-labs code whose
-// original notices appear below.
-//
-// It is distributed under the same license conditions as the
-// original code from which it is derived.
-//
-// Much love to the original authors for their work.
-// **********************************************************
-
-// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package contracts
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/coreth/accounts/abi/bind"
 	"github.com/ava-labs/coreth/accounts/abi/bind/backends"
+	"github.com/ava-labs/coreth/accounts/keystore"
+	"github.com/ava-labs/coreth/consensus/dummy"
 	admin "github.com/ava-labs/coreth/contracts/build_contracts/admin/src"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/rawdb"
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/eth"
+	"github.com/ava-labs/coreth/eth/ethadmin"
+	"github.com/ava-labs/coreth/eth/ethconfig"
+	"github.com/ava-labs/coreth/node"
 
 	"github.com/ava-labs/coreth/params"
 )
@@ -42,12 +43,14 @@ var (
 	gasFeeKey, _    = crypto.HexToECDSA("04214cc61e1feaf005aa25b7771d33ca5c4aea959d21fe9a1429f822fa024171")
 	blacklistKey, _ = crypto.HexToECDSA("b32d5aa5b8f4028218538c8c5b14b5c14f3f2e35b236e4bbbff09b669e69e46c")
 	dummyKey, _     = crypto.HexToECDSA("62802c57c0e3c24ae0ce354f7d19f7659ddbe506547b00e9e6a722980d2fed3d")
+	blackHoleKey, _ = crypto.HexToECDSA("50cdff9c21002158e2a18b73c2504f8982332e05b5c3b26d3cffdd2f1291796a")
 
 	adminAddr     = crypto.PubkeyToAddress(adminKey.PublicKey)
 	kycAddr       = crypto.PubkeyToAddress(kycKey.PublicKey)
 	gasFeeAddr    = crypto.PubkeyToAddress(gasFeeKey.PublicKey)
 	blacklistAddr = crypto.PubkeyToAddress(blacklistKey.PublicKey)
 	dummyAddr     = crypto.PubkeyToAddress(dummyKey.PublicKey)
+	blackholeAddr = crypto.PubkeyToAddress(blackHoleKey.PublicKey)
 
 	AdminProxyAddr = common.HexToAddress("0x010000000000000000000000000000000000000a")
 
@@ -56,6 +59,10 @@ var (
 	KYC_ROLE       = big.NewInt(4)
 	BLACKLIST_ROLE = big.NewInt(8)
 )
+
+type ETHChain struct {
+	backend *eth.Ethereum
+}
 
 func TestAdminRoleFunctions(t *testing.T) {
 	contractAddr := AdminProxyAddr
@@ -312,6 +319,123 @@ func TestDummySession(t *testing.T) {
 
 	_, err = dummySession.GrantRole(dummyAddr, ADMIN_ROLE)
 	assert.EqualError(t, err, errAccessDeniedMsg)
+}
+
+func TestEthAdmin(t *testing.T) {
+	contractAddr := AdminProxyAddr
+
+	// Initialize TransactOpts for each key
+	gasFeeOpts, err := bind.NewKeyedTransactorWithChainID(gasFeeKey, big.NewInt(1337))
+	assert.NoError(t, err)
+
+	// Generate GenesisAlloc
+	alloc := makeGenesisAllocation()
+
+	// Generate SimulatedBackend
+	sim := backends.NewSimulatedBackendWithInitialAdmin(alloc, gasLimit, gasFeeAddr)
+	defer func() {
+		err := sim.Close()
+		assert.NoError(t, err)
+	}()
+
+	sim.Commit(true)
+
+	// Create a bew Eth chain to generate an AdminController from its backend
+	// Simulated backed will not do
+	ethChain := newETHChain(t)
+
+	ac := ethadmin.NewController(ethChain.backend.APIBackend)
+	sim.Blockchain().SetAdminController(ac)
+
+	latestHeader, state := getLatestHeaderAndState(t, sim)
+
+	bf := ac.GetFixedBaseFee(latestHeader, state)
+	assert.EqualValues(t, big.NewInt(0), big.NewInt(int64(bf.Cmp(big.NewInt(int64(params.SunrisePhase0BaseFee))))))
+
+	adminContract, err := admin.NewBuild(contractAddr, sim)
+	assert.NoError(t, err)
+
+	// BuildSession Initialization
+	gasFeeSession := admin.BuildSession{Contract: adminContract, TransactOpts: *gasFeeOpts}
+
+	// Add Gas Fee Role in the address
+	_, err = gasFeeSession.GrantRole(gasFeeAddr, GAS_FEE_ROLE)
+	assert.NoError(t, err)
+
+	sim.Commit(true)
+
+	_, err = gasFeeSession.SetBaseFee(big.NewInt(1))
+	assert.NoError(t, err)
+
+	sim.Commit(true)
+
+	bf = ac.GetFixedBaseFee(latestHeader, state)
+	// Despite the fact that the base fee changed, the Admin Controller still tries to get it from the previous role.
+	// Therefore, it should return the SunrisePhase0BaseFee value
+	assert.EqualValues(t, big.NewInt(0), big.NewInt(int64(bf.Cmp(big.NewInt(int64(params.SunrisePhase0BaseFee))))))
+
+	// Get new block's header
+	latestHeader, state = getLatestHeaderAndState(t, sim)
+
+	bf = ac.GetFixedBaseFee(latestHeader, state)
+
+	// Now with the new block's header, Base Fee should be the new one.
+	assert.EqualValues(t, big.NewInt(1), bf)
+}
+
+func getLatestHeaderAndState(t *testing.T, sim *backends.SimulatedBackend) (*types.Header, *state.StateDB) {
+	latestHeader := sim.Blockchain().LastAcceptedBlock().Header()
+	state, err := sim.Blockchain().State()
+	assert.NoError(t, err)
+
+	return latestHeader, state
+}
+
+// newETHChain creates an Ethereum blockchain with the given configs.
+func newETHChain(t *testing.T) *ETHChain {
+	chainID := big.NewInt(1)
+	initialBalance := big.NewInt(1000000000000000000)
+
+	fundedKey, err := keystore.NewKey(rand.Reader)
+	assert.NoError(t, err)
+
+	// configure the chain
+	config := ethconfig.NewDefaultConfig()
+	chainConfig := &params.ChainConfig{
+		ChainID:             chainID,
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        big.NewInt(0),
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+	}
+
+	config.Genesis = &core.Genesis{
+		Config:     chainConfig,
+		Nonce:      0,
+		Number:     0,
+		ExtraData:  hexutil.MustDecode("0x00"),
+		GasLimit:   gasLimit,
+		Difficulty: big.NewInt(0),
+		Alloc:      core.GenesisAlloc{fundedKey.Address: {Balance: initialBalance}},
+	}
+
+	node, err := node.New(&node.Config{})
+	assert.NoError(t, err)
+
+	backend, err := eth.New(node, &config, new(dummy.ConsensusCallbacks), rawdb.NewMemoryDatabase(), eth.DefaultSettings, common.Hash{}, &mockable.Clock{})
+	assert.NoError(t, err)
+
+	chain := &ETHChain{backend: backend}
+	backend.SetEtherbase(blackholeAddr)
+
+	return chain
 }
 
 func makeGenesisAllocation() core.GenesisAlloc {

--- a/core/admin/admin.go
+++ b/core/admin/admin.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+
+package admin
+
+import (
+	"math/big"
+
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/core/types"
+)
+
+// Admin interface to control administrative tasks, which are intended to
+// be controlled on block level like BaseFee or Blacklisting or KYC
+type AdminController interface {
+	// Get the FixedBaseFee which should applied for blocks after height
+	GetFixedBaseFee(head *types.Header, state *state.StateDB) *big.Int
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -39,6 +49,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/coreth/consensus"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/state/snapshot"
@@ -149,8 +160,9 @@ var DefaultCacheConfig = &CacheConfig{
 // included in the canonical one where as GetBlockByNumber always represents the
 // canonical chain.
 type BlockChain struct {
-	chainConfig *params.ChainConfig // Chain & network configuration
-	cacheConfig *CacheConfig        // Cache configuration for pruning
+	chainConfig *params.ChainConfig   // Chain & network configuration
+	cacheConfig *CacheConfig          // Cache configuration for pruning
+	adminCtrl   admin.AdminController // Block based administrative control
 
 	db ethdb.Database // Low level persistent database to store final content in
 
@@ -447,6 +459,11 @@ func (bc *BlockChain) stopAcceptor() {
 	bc.acceptorWg.Wait()
 	bc.acceptorClosed = true
 	close(bc.acceptorQueue)
+}
+
+// SetAdminController sets the admin Controller.
+func (bc *BlockChain) SetAdminController(ctrl admin.AdminController) {
+	bc.adminCtrl = ctrl
 }
 
 func (bc *BlockChain) InitializeSnapshots() {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2021, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -28,6 +38,7 @@ package core
 
 import (
 	"github.com/ava-labs/coreth/consensus"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/state/snapshot"
@@ -250,6 +261,9 @@ func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 
 // Config retrieves the chain's fork configuration.
 func (bc *BlockChain) Config() *params.ChainConfig { return bc.chainConfig }
+
+// AdminController retrieves the chain's admin controller.
+func (bc *BlockChain) AdminController() admin.AdminController { return bc.adminCtrl }
 
 // Engine retrieves the blockchain's consensus engine.
 func (bc *BlockChain) Engine() consensus.Engine { return bc.engine }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -33,6 +43,7 @@ import (
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/consensus/misc"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/core/vm"
@@ -312,7 +323,7 @@ func makeHeader(chain consensus.ChainReader, config *params.ChainConfig, parent 
 	}
 	if chain.Config().IsApricotPhase3(timestamp) {
 		var err error
-		header.Extra, header.BaseFee, err = dummy.CalcBaseFee(chain.Config(), parent.Header(), time)
+		header.Extra, header.BaseFee, err = dummy.CalcBaseFee(chain.Config(), chain.AdminController(), parent.Header(), time)
 		if err != nil {
 			panic(err)
 		}
@@ -329,6 +340,7 @@ func (cr *fakeChainReader) Config() *params.ChainConfig {
 	return cr.config
 }
 
+func (cr *fakeChainReader) AdminController() admin.AdminController                  { return nil }
 func (cr *fakeChainReader) CurrentHeader() *types.Header                            { return nil }
 func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *types.Header           { return nil }
 func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *types.Header          { return nil }

--- a/core/error.go
+++ b/core/error.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -102,3 +112,13 @@ var (
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
 )
+
+func CompareErrors(a, b error) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Error() == b.Error()
+}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2021, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -153,7 +163,7 @@ func TestSetupGenesis(t *testing.T) {
 			db := rawdb.NewMemoryDatabase()
 			config, hash, err := test.fn(db)
 			// Check the return values.
-			if !reflect.DeepEqual(err, test.wantErr) {
+			if !CompareErrors(err, test.wantErr) {
 				spew := spew.ConfigState{DisablePointerAddresses: true, DisableCapacities: true}
 				t.Errorf("returned error %#v, want %#v", spew.NewFormatter(err), spew.NewFormatter(test.wantErr))
 			}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -326,7 +326,6 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		UncleHash: types.EmptyUncleHash,
 	}
 	if config.IsApricotPhase3(new(big.Int).SetUint64(header.Time)) {
-		// ToDo: AdminController
 		header.Extra, header.BaseFee, _ = dummy.CalcBaseFee(config, nil, parent.Header(), header.Time)
 	}
 	if config.IsApricotPhase4(new(big.Int).SetUint64(header.Time)) {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2021, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -316,7 +326,8 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		UncleHash: types.EmptyUncleHash,
 	}
 	if config.IsApricotPhase3(new(big.Int).SetUint64(header.Time)) {
-		header.Extra, header.BaseFee, _ = dummy.CalcBaseFee(config, parent.Header(), header.Time)
+		// ToDo: AdminController
+		header.Extra, header.BaseFee, _ = dummy.CalcBaseFee(config, nil, parent.Header(), header.Time)
 	}
 	if config.IsApricotPhase4(new(big.Int).SetUint64(header.Time)) {
 		header.BlockGasCost = big.NewInt(0)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2021, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -38,6 +48,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
@@ -120,6 +131,10 @@ func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) even
 
 func (bc *testBlockChain) SenderCacher() *TxSenderCacher {
 	return newTxSenderCacher(1)
+}
+
+func (bc *testBlockChain) AdminController() admin.AdminController {
+	return nil
 }
 
 func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Transaction {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -36,6 +46,7 @@ import (
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/bloombits"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
@@ -66,6 +77,10 @@ func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 
 func (b *EthAPIBackend) GetVMConfig() *vm.Config {
 	return b.eth.blockchain.GetVMConfig()
+}
+
+func (b *EthAPIBackend) AdminController() admin.AdminController {
+	return b.eth.blockchain.AdminController()
 }
 
 func (b *EthAPIBackend) CurrentBlock() *types.Block {
@@ -202,6 +217,14 @@ func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash r
 
 func (b *EthAPIBackend) BadBlocks() ([]*types.Block, []*core.BadBlockReason) {
 	return b.eth.blockchain.BadBlocks()
+}
+
+func (b *EthAPIBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
+	return nil, nil
+}
+
+func (b *EthAPIBackend) StateByHeader(ctx context.Context, header *types.Header) (*state.StateDB, error) {
+	return b.eth.BlockChain().StateAt(header.Root)
 }
 
 func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error) {

--- a/eth/ethadmin/ethadmin.go
+++ b/eth/ethadmin/ethadmin.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+
+package ethadmin
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"sync"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/params"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	contractAddr = common.Address{
+		1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 10,
+	}
+	baseFeeSlot = common.Hash{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+	}
+)
+
+type AdminControllerBackend interface {
+	StateByHeader(ctx context.Context, header *types.Header) (*state.StateDB, error)
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+}
+
+type AdminController struct {
+	ctx              context.Context
+	backend          AdminControllerBackend
+	lastHead         common.Hash // Last block hash used for validating sequence
+	scanHeight       big.Int     // Last scanned block height
+	lastChangeHeight big.Int     // Last known block where changes were made
+
+	baseFee *big.Int // BaseFee valid from lastChangeHeight to
+
+	lock sync.RWMutex
+}
+
+// NewAdmin returns a new Admin instance used for fast admi state retrieval
+func NewController(backend AdminControllerBackend) *AdminController {
+	admin := &AdminController{
+		ctx:     context.Background(),
+		backend: backend,
+	}
+
+	headEvent := make(chan core.ChainHeadEvent, 1)
+	backend.SubscribeChainHeadEvent(headEvent)
+	go func() {
+		for ev := range headEvent {
+			admin.consume(&ev)
+		}
+	}()
+
+	return admin
+}
+
+func (a *AdminController) consume(ev *core.ChainHeadEvent) {
+	// Acquire write lock
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	changed := true
+	if a.lastHead == ev.Block.ParentHash() {
+		// We are in order, scan for admin tx
+		changed = a.process(ev)
+	}
+	a.lastHead = ev.Block.Hash()
+	blockHeight := ev.Block.Number()
+
+	// If a relevant admin TX found, reset cache
+	if changed {
+		a.lastChangeHeight = *blockHeight
+		a.baseFee = nil
+	}
+	a.scanHeight = *blockHeight
+}
+
+func (a *AdminController) process(ev *core.ChainHeadEvent) bool {
+	changed := false
+	for _, tx := range ev.Block.Transactions() {
+		if tx.To() != nil && bytes.Equal(tx.To().Bytes(), contractAddr[:]) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (a *AdminController) GetFixedBaseFee(head *types.Header, state *state.StateDB) *big.Int {
+	a.lock.RLock()
+	if a.baseFee != nil && a.inScanRange(head) {
+		a.lock.RUnlock()
+		return a.baseFee
+	}
+	a.lock.RUnlock()
+
+	if state == nil {
+		var err error
+		if state, err = a.backend.StateByHeader(a.ctx, head); err != nil {
+			log.Debug("cannot get stateDB -> using default: %s", err)
+			return new(big.Int).SetUint64(params.SunrisePhase0BaseFee)
+		}
+	}
+
+	baseFee := new(big.Int).SetBytes(state.GetState(contractAddr, baseFeeSlot).Bytes())
+
+	if baseFee.Cmp(common.Big0) == 0 {
+		baseFee.SetUint64(params.SunrisePhase0BaseFee)
+	}
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if a.baseFee == nil && a.inScanRange(head) {
+		a.baseFee = baseFee
+	}
+
+	return baseFee
+}
+
+func (a *AdminController) inScanRange(head *types.Header) bool {
+	return head.Number.Cmp(&a.lastChangeHeight) >= 0 && head.Number.Cmp(&a.scanHeight) <= 0
+}

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -34,6 +44,7 @@ import (
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
@@ -88,6 +99,10 @@ func (b *testBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {
 	return b.chain.Config()
+}
+
+func (b *testBackend) AdminController() admin.AdminController {
+	return b.chain.AdminController()
 }
 
 func (b *testBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -148,7 +158,7 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 	bigTimestamp := big.NewInt(timestamp)
 	if w.chainConfig.IsApricotPhase3(bigTimestamp) {
 		var err error
-		header.Extra, header.BaseFee, err = dummy.CalcBaseFee(w.chainConfig, parent.Header(), uint64(timestamp))
+		header.Extra, header.BaseFee, err = dummy.CalcBaseFee(w.chainConfig, w.chain.AdminController(), parent.Header(), uint64(timestamp))
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate new base fee: %w", err)
 		}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1375,7 +1375,7 @@ func (vm *VM) verifyTxAtTip(tx *Tx) error {
 	timestamp := vm.clock.Time().Unix()
 	bigTimestamp := big.NewInt(timestamp)
 	if vm.chainConfig.IsApricotPhase3(bigTimestamp) {
-		_, nextBaseFee, err = dummy.EstimateNextBaseFee(vm.chainConfig, parentHeader, uint64(timestamp))
+		_, nextBaseFee, err = dummy.EstimateNextBaseFee(vm.chainConfig, vm.eth.APIBackend.AdminController(), parentHeader, uint64(timestamp))
 		if err != nil {
 			// Return extremely detailed error since CalcBaseFee should never encounter an issue here
 			return fmt.Errorf("failed to calculate base fee with parent timestamp (%d), parent ExtraData: (0x%x), and current timestamp (%d): %w", parentHeader.Time, parentHeader.Extra, timestamp, err)


### PR DESCRIPTION
# Admin interface + implementation for setting gasFees via TX

This is the first implementation on top of #20 and provides an interface to state set by the Admin SmartContract.
Also this controller should be used for other tasks which change code in the existing code base to limit code changes in there.

One example could be deciding if a special tx type is gas free or not.

State changes are re-evaluated after block processing, so there could be differences when using the admin features inside smart contracts compared to how the node internal handles this.
For example if a block with 2 TX is executed, and the first TX changes a KYC state, the second TX works with the new KYC state, while the node internal processing only knows the new state AFTER the block was accepted.