### PR TITLE
EVM ChainID 502 -> 501

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -58,7 +58,7 @@ var (
 	// CaminoChainID ...
 	CaminoChainID = big.NewInt(500)
 	// CaminoChainID ...
-	ColumbusChainID = big.NewInt(502)
+	ColumbusChainID = big.NewInt(501)
 
 	errNonGenesisForkByHeight = errors.New("coreth only supports forking by height at the genesis block")
 )


### PR DESCRIPTION
## EVM ChainID 502 -> 501
Initial selected chainID 502 now goes to 501 to be in sync with chainIDs from core