### PR TITLE
Fee reward collection on the C-chain

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -166,6 +166,9 @@ func (self *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, ctrl 
 	if config.IsApricotPhase5(timestamp) {
 		blockGasCostStep = ApricotPhase5BlockGasCostStep
 	}
+	if config.IsSunrisePhase0(timestamp) {
+		blockGasCostStep = common.Big0
+	}
 	expectedBlockGasCost := calcBlockGasCost(
 		ApricotPhase4TargetBlockRate,
 		ApricotPhase4MinBlockGasCost,
@@ -367,6 +370,9 @@ func (self *DummyEngine) Finalize(chain consensus.ChainHeaderReader, block *type
 		if chain.Config().IsApricotPhase5(new(big.Int).SetUint64(block.Time())) {
 			blockGasCostStep = ApricotPhase5BlockGasCostStep
 		}
+		if chain.Config().IsSunrisePhase0(new(big.Int).SetUint64(block.Time())) {
+			blockGasCostStep = common.Big0
+		}
 		// Calculate the expected blockGasCost for this block.
 		// Note: this is a deterministic transtion that defines an exact block fee for this block.
 		blockGasCost := calcBlockGasCost(
@@ -417,6 +423,9 @@ func (self *DummyEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, 
 		blockGasCostStep := ApricotPhase4BlockGasCostStep
 		if chain.Config().IsApricotPhase5(new(big.Int).SetUint64(header.Time)) {
 			blockGasCostStep = ApricotPhase5BlockGasCostStep
+		}
+		if chain.Config().IsSunrisePhase0(new(big.Int).SetUint64(header.Time)) {
+			blockGasCostStep = common.Big0
 		}
 		// Calculate the required block gas cost for this block.
 		header.BlockGasCost = calcBlockGasCost(

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -189,6 +189,7 @@ func (b *Block) Accept(context.Context) error {
 		return fmt.Errorf("failed to put %s as the last accepted block: %w", b.ID(), err)
 	}
 
+	b.calculateAndCollectRewards()
 	for _, tx := range b.atomicTxs {
 		// Remove the accepted transaction from the mempool
 		vm.mempool.RemoveTx(tx)

--- a/plugin/evm/camino_block_fee_collection.go
+++ b/plugin/evm/camino_block_fee_collection.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// calculateAndCollectRewards calculates the rewards and issues the CollectRewardsTx
+// Errors are logged and ignored as they are not affecting the other actions
+func (b *Block) calculateAndCollectRewards() {
+	state, err := b.vm.blockChain.State()
+	if err != nil {
+		return
+	}
+	calc, err := b.calculateRewards(state)
+	if err != nil {
+		return
+	}
+
+	tx, err := b.createRewardsCollectionTx(calc)
+	if err != nil {
+		log.Info("Issuing of the rewards collection skipped", "error", err)
+	} else {
+		log.Info("Issuing of the rewards collection tx", "txID", tx.ID(), "rewards to export", calc.ValidatorRewardToExport)
+		b.vm.issueTx(tx, true /*=local*/)
+	}
+}
+
+func (b *Block) calculateRewards(state *state.StateDB) (*RewardCalculation, error) {
+	header := b.ethBlock.Header()
+
+	feesBurned := state.GetBalance(header.Coinbase)
+	validatorRewards := state.GetState(header.Coinbase, Slot1).Big()
+	incentivePoolRewards := state.GetState(header.Coinbase, Slot2).Big()
+
+	calculation, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		FeeRewardRate,
+		IncentivePoolRewardRate,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if calculation.ValidatorRewardToExport < FeeRewardMinAmountToExport {
+		return nil, fmt.Errorf("calculated fee reward amount %d is less than the minimum amount to export", calculation.ValidatorRewardToExport)
+	}
+
+	return &calculation, nil
+}
+
+func (b *Block) createRewardsCollectionTx(calculation *RewardCalculation) (*Tx, error) {
+	if calculation == nil {
+		return nil, fmt.Errorf("no rewards to collect")
+	}
+
+	h := b.ethBlock.Header()
+	tx, err := b.vm.NewCollectRewardsTx(
+		calculation.Result(),
+		b.ID(),
+		b.ethBlock.Time(),
+		h.Coinbase,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}

--- a/plugin/evm/codec.go
+++ b/plugin/evm/codec.go
@@ -33,6 +33,7 @@ func init() {
 		c.RegisterType(&secp256k1fx.Credential{}),
 		c.RegisterType(&secp256k1fx.Input{}),
 		c.RegisterType(&secp256k1fx.OutputOwners{}),
+		c.RegisterType(&UnsignedCollectRewardsTx{}),
 		Codec.RegisterCodec(codecVersion, c),
 	)
 

--- a/plugin/evm/collect_rewards_tx.go
+++ b/plugin/evm/collect_rewards_tx.go
@@ -1,0 +1,285 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/avalanchego/chains/atomic"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	FeeRewardMinAmountToExport    = uint64(200_000)
+	FeeRewardExportAddressStr     = "0x010000000000000000000000000000000000000c"
+	IncentivePoolRewardAddressStr = "0x010000000000000000000000000000000000000c"
+
+	// Assumption: Following rates are denominated to uint64 from floating point ratio (ratio * evm.percentDenominator)
+	FeeRewardRate           = uint64(300_000)
+	IncentivePoolRewardRate = uint64(300_000)
+)
+
+var (
+	_                           UnsignedAtomicTx = &UnsignedCollectRewardsTx{}
+	FeeRewardExportAddress                       = common.HexToAddress(FeeRewardExportAddressStr)
+	IncentivePoolRewardAddress                   = common.HexToAddress(IncentivePoolRewardAddressStr)
+	FeeRewardExportAddressId, _                  = ids.ToShortID(FeeRewardExportAddress.Bytes())
+)
+
+// UnsignedCollectRewardsTx is an internal rewards collection transaction
+type UnsignedCollectRewardsTx struct {
+	avax.Metadata
+	// ID of the network on which this tx was issued
+	NetworkID uint32 `serialize:"true" json:"networkID"`
+	// ID of this blockchain.
+	BlockchainID ids.ID `serialize:"true" json:"blockchainID"`
+	// Which chain to send the funds to
+	DestinationChain ids.ID `serialize:"true" json:"destinationChain"`
+	// Outputs that are exported to the chain
+	ExportedOutputs []*avax.TransferableOutput `serialize:"true" json:"exportedOutputs"`
+
+	BlockId        ids.ID `serialize:"true" json:"blockId"`
+	BlockTimestamp uint64 `serialize:"true" json:"blockTimestamp"`
+
+	RewardCalculation RewardCalculationResult `serialize:"true" json:"rewardCalculation"`
+
+	Coinbase common.Address `serialize:"true" json:"coinbase"`
+}
+
+// InputUTXOs returns a set of all the hash(address:nonce) exporting funds.
+func (tx *UnsignedCollectRewardsTx) InputUTXOs() set.Set[ids.ID] {
+	// Not sure if it will be needed - mock
+	return set.NewSet[ids.ID](0)
+}
+
+// Verify this transaction is well-formed
+func (tx *UnsignedCollectRewardsTx) Verify(
+	ctx *snow.Context,
+	_rules params.Rules,
+) error {
+	switch {
+	case tx == nil:
+		return errNilTx
+	case tx.NetworkID != ctx.NetworkID:
+		return errWrongNetworkID
+	case ctx.ChainID != tx.BlockchainID:
+		return errWrongBlockchainID
+	}
+
+	if err := tx.RewardCalculation.Verify(); err != nil {
+		return err
+	}
+
+	// Make sure that the tx has a valid peer chain ID
+	if err := verify.SameSubnet(ctx, tx.DestinationChain); err != nil {
+		return errWrongChainID
+	}
+	if tx.DestinationChain != constants.PlatformChainID {
+		return errWrongChainID
+	}
+
+	return nil
+}
+
+func (tx *UnsignedCollectRewardsTx) GasUsed(bool) (uint64, error) {
+	return 0, nil
+}
+
+// Amount of [assetID] burned by this transaction
+func (tx *UnsignedCollectRewardsTx) Burned(_assetID ids.ID) (uint64, error) {
+	// Let me lie here
+	return 0, nil
+}
+
+// SemanticVerify this transaction is valid.
+func (tx *UnsignedCollectRewardsTx) SemanticVerify(
+	vm *VM,
+	_stx *Tx,
+	b *Block,
+	_baseFee *big.Int,
+	rules params.Rules,
+) error {
+	if err := tx.Verify(vm.ctx, rules); err != nil {
+		return err
+	}
+
+	stateDB, err := vm.blockChain.State()
+	if err != nil {
+		log.Error("Cannot access current EVM stateDB", "error", err)
+		return fmt.Errorf("cannot access current EVM stateDB: %w", err)
+	}
+	if tx.Coinbase != b.ethBlock.Coinbase() {
+		return fmt.Errorf("coinbase address mismatch Tx %s vs Block's %s", tx.Coinbase.Hex(), b.ethBlock.Coinbase().Hex())
+	}
+
+	calculation := tx.RewardCalculation.Calculation()
+
+	currValidatorRewardPayedOut := stateDB.GetState(tx.Coinbase, Slot1).Big()
+	if calculation.PrevValidatorRewards.Cmp(currValidatorRewardPayedOut) != 0 {
+		log.Info("validator rewards mismatch", "prevFeesBurned", calculation.PrevFeesBurned, "currValidatorRewardPayedOut", currValidatorRewardPayedOut)
+		return fmt.Errorf("validator rewards mismatch")
+	}
+
+	ipRewardsPayedOut := stateDB.GetState(tx.Coinbase, Slot2).Big()
+	if calculation.PrevIncentivePoolRewards.Cmp(ipRewardsPayedOut) != 0 {
+		log.Info("Incentive pool rewards mismatch", "prevIncentivePoolRewards", calculation.PrevIncentivePoolRewards, "ipRewardsPayedOut", ipRewardsPayedOut)
+		return fmt.Errorf("incentive pool balance mismatch")
+	}
+
+	// 1. Redo the calculation and compare the results
+	prevCalc, err := CalculateRewards(calculation.PrevFeesBurned, calculation.PrevValidatorRewards, calculation.PrevIncentivePoolRewards, FeeRewardRate, IncentivePoolRewardRate)
+	if err != nil {
+		return fmt.Errorf("cannot repeat the reward calculation on previous state: %w", err)
+	}
+
+	if calculation.ValidatorRewardAmount.Cmp(prevCalc.ValidatorRewardAmount) != 0 ||
+		calculation.IncentivePoolRewardAmount.Cmp(prevCalc.IncentivePoolRewardAmount) != 0 ||
+		calculation.ValidatorRewardToExport != prevCalc.ValidatorRewardToExport ||
+		calculation.CoinbaseAmountToSub.Cmp(prevCalc.CoinbaseAmountToSub) != 0 {
+		return fmt.Errorf("repeated reward calculation on previous state does not match the Tx")
+	}
+
+	// 2. Check that the state is correct - do the calculation on current state and check calculated rewards are not less than in the Tx
+	currFeesBurned := stateDB.GetBalance(tx.Coinbase)
+	if currFeesBurned.Cmp(calculation.PrevFeesBurned) < 0 {
+		return fmt.Errorf("current Coinbase balance is less than the balance the CollectRewardsTx was issued for")
+	}
+
+	currCalc, err := CalculateRewards(currFeesBurned, currValidatorRewardPayedOut, ipRewardsPayedOut, FeeRewardRate, IncentivePoolRewardRate)
+	if err != nil {
+		return fmt.Errorf("cannot repeat the reward calculation on current state: %w", err)
+	}
+
+	if calculation.ValidatorRewardAmount.Cmp(currCalc.ValidatorRewardAmount) > 0 ||
+		calculation.IncentivePoolRewardAmount.Cmp(currCalc.IncentivePoolRewardAmount) > 0 ||
+		calculation.ValidatorRewardToExport > currCalc.ValidatorRewardToExport ||
+		calculation.CoinbaseAmountToSub.Cmp(currCalc.CoinbaseAmountToSub) > 0 {
+		return fmt.Errorf("repeated reward calculation on current state does not follow the requirements")
+	}
+
+	// 3. Check the UTXO's owner, amount & currency
+	if len(tx.ExportedOutputs) != 1 {
+		return fmt.Errorf("expected single exported output, got %d", len(tx.ExportedOutputs))
+	}
+
+	eo := tx.ExportedOutputs[0]
+	if eo.AssetID() != vm.ctx.AVAXAssetID {
+		return fmt.Errorf("expected AVAX asset in ExportedOutput, got %s", eo.AssetID())
+	}
+
+	if eo.Out.Amount() != calculation.ValidatorRewardToExport {
+		return fmt.Errorf("expected %d AVAX in ExportedOutput, got %d", calculation.ValidatorRewardToExport, eo.Out.Amount())
+	}
+
+	out, ok := eo.Out.(*secp256k1fx.TransferOutput)
+	if !ok {
+		return fmt.Errorf("expected secp256k1fx.TransferOutput in ExportedOutput, got %T", eo.Out)
+	}
+
+	if len(out.OutputOwners.Addrs) != 1 {
+		return fmt.Errorf("expected single output owner in ExportedOutput")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get short ID for fee reward export address: %w", err)
+	}
+	if out.OutputOwners.Addrs[0] != FeeRewardExportAddressId {
+		return fmt.Errorf("expected %s as output owner of the fee reward, got %s", FeeRewardExportAddressStr, out.OutputOwners.Addrs[0].Hex())
+	}
+
+	return nil
+}
+
+// AtomicOps returns the atomic operations for this transaction.
+func (tx *UnsignedCollectRewardsTx) AtomicOps() (ids.ID, *atomic.Requests, error) {
+	txID := tx.ID()
+
+	out := tx.ExportedOutputs[0]
+	utxo := &avax.UTXO{
+		UTXOID: avax.UTXOID{
+			TxID:        txID,
+			OutputIndex: uint32(0),
+		},
+		Asset: avax.Asset{ID: out.AssetID()},
+		Out:   out.Out,
+	}
+
+	utxoBytes, err := Codec.Marshal(codecVersion, utxo)
+	if err != nil {
+		return ids.ID{}, nil, err
+	}
+	utxoID := utxo.InputID()
+	elem := &atomic.Element{
+		Key:   utxoID[:],
+		Value: utxoBytes,
+	}
+	if out, ok := utxo.Out.(avax.Addressable); ok {
+		elem.Traits = out.Addresses()
+	}
+
+	elems := []*atomic.Element{elem}
+	return tx.DestinationChain, &atomic.Requests{PutRequests: elems}, nil
+}
+
+func (vm *VM) NewCollectRewardsTx(
+	calculation RewardCalculationResult,
+	blockId ids.ID,
+	blockTimestamp uint64,
+	coinbase common.Address,
+) (*Tx, error) {
+	// Create the transaction
+	utx := &UnsignedCollectRewardsTx{
+		NetworkID:         vm.ctx.NetworkID,
+		BlockchainID:      vm.ctx.ChainID,
+		DestinationChain:  constants.PlatformChainID,
+		BlockId:           blockId,
+		BlockTimestamp:    blockTimestamp,
+		RewardCalculation: calculation,
+		Coinbase:          coinbase,
+	}
+
+	utx.ExportedOutputs = []*avax.TransferableOutput{{
+		Asset: avax.Asset{ID: vm.ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: calculation.ValidatorRewardToExport,
+			OutputOwners: secp256k1fx.OutputOwners{
+				Locktime:  0,
+				Threshold: 1,
+				Addrs:     []ids.ShortID{FeeRewardExportAddressId},
+			},
+		},
+	}}
+
+	tx := &Tx{UnsignedAtomicTx: utx}
+	if err := tx.Sign(vm.codec, nil); err != nil {
+		return nil, err
+	}
+
+	return tx, utx.Verify(vm.ctx, vm.currentRules())
+}
+
+// EVMStateTransfer executes the state update from the atomic export transaction
+func (tx *UnsignedCollectRewardsTx) EVMStateTransfer(ctx *snow.Context, state *state.StateDB) error {
+	calculation := tx.RewardCalculation.Calculation()
+	state.SubBalance(tx.Coinbase, calculation.CoinbaseAmountToSub)
+	validatorRewards := new(big.Int).Add(calculation.PrevValidatorRewards, calculation.ValidatorRewardAmount)
+
+	ipRewards := new(big.Int).Add(calculation.PrevIncentivePoolRewards, calculation.IncentivePoolRewardAmount)
+	state.AddBalance(IncentivePoolRewardAddress, calculation.IncentivePoolRewardAmount)
+
+	state.SetState(tx.Coinbase, Slot1, common.BigToHash(validatorRewards))
+	state.SetState(tx.Coinbase, Slot2, common.BigToHash(ipRewards))
+
+	return nil
+}

--- a/plugin/evm/reward_calculator.go
+++ b/plugin/evm/reward_calculator.go
@@ -1,0 +1,168 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	percentDenominator uint64 = 1_000_000
+	x2cRateUint64             = uint64(x2cRateInt64)
+)
+
+var (
+	Slot1 = common.Hash{0x01}
+	Slot2 = common.Hash{0x02}
+
+	errZeroRewardCalculated            = errors.New("no rewards collected")
+	errRewardAndAmountToExportMismatch = errors.New("calculated reward differs with amount to export")
+)
+
+type RewardCalculation struct {
+	ValidatorRewardAmount     *big.Int
+	ValidatorRewardToExport   uint64
+	IncentivePoolRewardAmount *big.Int
+	CoinbaseAmountToSub       *big.Int
+
+	// Needed for validation of the Tx:
+	// Current coinbase balance may differ from the one the Tx was issued with. Here to redo the calculation.
+	PrevFeesBurned *big.Int
+	// have to match the current state, hence no other RewardCollection Tx has been processed in-between.
+	PrevValidatorRewards     *big.Int
+	PrevIncentivePoolRewards *big.Int
+}
+
+type RewardCalculationResult struct {
+	ValidatorRewardAmount     common.Hash `serialize:"true" json:"validatorRewardAmount"`
+	ValidatorRewardToExport   uint64      `serialize:"true" json:"validatorRewardToExport"`
+	IncentivePoolRewardAmount common.Hash `serialize:"true" json:"incentivePoolRewardAmount"`
+	CoinbaseAmountToSub       common.Hash `serialize:"true" json:"coinbaseAmountToSub"`
+
+	PrevFeesBurned           common.Hash `serialize:"true" json:"prevFeesBurned"`
+	PrevValidatorRewards     common.Hash `serialize:"true" json:"prevValidatorRewards"`
+	PrevIncentivePoolRewards common.Hash `serialize:"true" json:"prevIncentivePoolRewards"`
+}
+
+func (rc RewardCalculation) Result() RewardCalculationResult {
+	return RewardCalculationResult{
+		ValidatorRewardAmount:     common.BigToHash(rc.ValidatorRewardAmount),
+		ValidatorRewardToExport:   rc.ValidatorRewardToExport,
+		IncentivePoolRewardAmount: common.BigToHash(rc.IncentivePoolRewardAmount),
+		CoinbaseAmountToSub:       common.BigToHash(rc.CoinbaseAmountToSub),
+		PrevFeesBurned:            common.BigToHash(rc.PrevFeesBurned),
+		PrevValidatorRewards:      common.BigToHash(rc.PrevValidatorRewards),
+		PrevIncentivePoolRewards:  common.BigToHash(rc.PrevIncentivePoolRewards),
+	}
+}
+
+func (rc RewardCalculation) Verify() error {
+	if rc.ValidatorRewardToExport == 0 ||
+		rc.ValidatorRewardAmount.Cmp(common.Big0) == 0 ||
+		rc.IncentivePoolRewardAmount.Cmp(common.Big0) == 0 {
+		return errZeroRewardCalculated
+	}
+
+	exportAmount := bigDiv(rc.ValidatorRewardAmount, x2cRateUint64).Uint64()
+	if exportAmount != rc.ValidatorRewardToExport {
+		return errRewardAndAmountToExportMismatch
+	}
+
+	return nil
+}
+
+func (res RewardCalculationResult) Calculation() RewardCalculation {
+	return RewardCalculation{
+		ValidatorRewardAmount:     res.ValidatorRewardAmount.Big(),
+		ValidatorRewardToExport:   res.ValidatorRewardToExport,
+		IncentivePoolRewardAmount: res.IncentivePoolRewardAmount.Big(),
+		CoinbaseAmountToSub:       res.CoinbaseAmountToSub.Big(),
+		PrevFeesBurned:            res.PrevFeesBurned.Big(),
+		PrevValidatorRewards:      res.PrevValidatorRewards.Big(),
+		PrevIncentivePoolRewards:  res.PrevIncentivePoolRewards.Big(),
+	}
+}
+
+func (res RewardCalculationResult) Verify() error {
+	return res.Calculation().Verify()
+}
+
+// CalculateRewards calculates the rewards for validators and incentive pool account
+//
+//	feesBurned: the amount of fees burned already, balance of the coinbase address
+//	validatorRewards: the amount of validator's rewards already paid out, state at slot 0 of coinbase
+//	incentivePoolRewards: the amount of incentive pool's rewards already paid out, state at slot 0 of
+//		incentive pool account
+//	feeRewardRate: the percentage of fees to be paid out to validators, denominated in `percentDenominator`
+//	incentivePoolRate: the percentage of fees to be paid out to incentive pool, denominated in `percentDenominator`
+func CalculateRewards(
+	feesBurned, validatorRewards, incentivePoolRewards *big.Int,
+	feeRewardRate, incentivePoolRate uint64,
+) (RewardCalculation, error) {
+	calc := RewardCalculation{
+		PrevFeesBurned:           feesBurned,
+		PrevValidatorRewards:     validatorRewards,
+		PrevIncentivePoolRewards: incentivePoolRewards,
+	}
+	errs := wrappers.Errs{}
+	bigZero := big.NewInt(0)
+
+	errs.Add(
+		errIf(feeRewardRate+incentivePoolRate > percentDenominator, errors.New("feeRewardRate + incentivePoolRate > 100%")),
+		errIf(feesBurned.Cmp(bigZero) < 0, errors.New("feesBurned < 0")),
+		errIf(validatorRewards.Cmp(bigZero) < 0, errors.New("validatorRewards < 0")),
+		errIf(incentivePoolRewards.Cmp(bigZero) < 0, errors.New("incentivePoolRewards < 0")),
+	)
+	if errs.Errored() {
+		return calc, errs.Err
+	}
+
+	totalFeesAmount := big.NewInt(0).Add(feesBurned, incentivePoolRewards)
+	totalFeesAmount.Add(totalFeesAmount, validatorRewards)
+
+	feeRewardAmount := calculateReward(totalFeesAmount, validatorRewards, feeRewardRate)
+
+	// Validator's reward is exported to the P-Chain, we intentionally loose precision so the C-Chain's
+	// "decimal loss" can be accumulated in the account for future collections
+	feeRewardAmount = bigDiv(feeRewardAmount, x2cRateUint64)
+	calc.ValidatorRewardToExport = feeRewardAmount.Uint64()
+	calc.ValidatorRewardAmount = bigMul(feeRewardAmount, x2cRateUint64)
+
+	calc.IncentivePoolRewardAmount = calculateReward(totalFeesAmount, incentivePoolRewards, incentivePoolRate)
+
+	calc.CoinbaseAmountToSub = new(big.Int).Add(calc.ValidatorRewardAmount, calc.IncentivePoolRewardAmount)
+
+	return calc, calc.Verify()
+}
+
+func calculateReward(total, alreadyPayed *big.Int, percentRate uint64) *big.Int {
+	reward := new(big.Int).Sub(
+		bigMul(total, percentRate),
+		bigMul(alreadyPayed, percentDenominator),
+	)
+
+	// denominate down from percentage
+	return bigDiv(reward, percentDenominator)
+}
+
+// bigMul: multiply value by rate
+func bigMul(value *big.Int, rate uint64) *big.Int {
+	return new(big.Int).Mul(value, big.NewInt(int64(rate)))
+}
+
+// bigDiv: divide value by rate
+func bigDiv(value *big.Int, rate uint64) *big.Int {
+	return new(big.Int).Div(value, big.NewInt(int64(rate)))
+}
+
+func errIf(cond bool, err error) error {
+	if cond {
+		return err
+	}
+	return nil
+}

--- a/plugin/evm/reward_calculator_test.go
+++ b/plugin/evm/reward_calculator_test.go
@@ -1,0 +1,431 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	ZERO = big.NewInt(0)
+	CAM1 = big.NewInt(1_000_000_000_000_000_000)
+)
+
+func TestRewardCalculationRatesExceed100Percent(t *testing.T) {
+	blackHoleAddressBalance := big.NewInt(1_000_000_000_000_000_000)
+	payedOutBalance := big.NewInt(0)
+	incentivePoolBalance := big.NewInt(0)
+	feeRewardRate := uint64(0.51 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.50 * float64(percentDenominator))
+
+	_, err := CalculateRewards(
+		blackHoleAddressBalance,
+		payedOutBalance,
+		incentivePoolBalance,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, "feeRewardRate + incentivePoolRate > 100%", err.Error())
+}
+
+func TestRewardCalculationCalculate10PercentReward(t *testing.T) {
+	blackHoleAddressBalance := big.NewInt(1_000_000_000_000_000_000)
+	payedOutBalance := big.NewInt(0)
+	incentivePoolBalance := big.NewInt(0)
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	calc, err := CalculateRewards(
+		blackHoleAddressBalance,
+		payedOutBalance,
+		incentivePoolBalance,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(100_000_000_000_000_000), calc.ValidatorRewardAmount)
+	assert.Equal(t, uint64(100_000_000), calc.ValidatorRewardToExport)
+	assert.Equal(t, big.NewInt(100_000_000_000_000_000), calc.IncentivePoolRewardAmount)
+	assert.Equal(t, big.NewInt(200_000_000_000_000_000), calc.CoinbaseAmountToSub)
+}
+
+func TestRewardCalculationCalculationWithoutFeeIncrementIsZeroRewards(t *testing.T) {
+	feesBurned := CAM1
+	validatorRewards := ZERO
+	incentivePoolRewards := ZERO
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	calc1, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc1 := big.NewInt(0).Sub(feesBurned, calc1.CoinbaseAmountToSub)
+	validatorAmountAfterCalc1 := big.NewInt(0).Add(validatorRewards, calc1.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc1 := big.NewInt(0).Add(incentivePoolRewards, calc1.IncentivePoolRewardAmount)
+
+	calc2, err := CalculateRewards(
+		coinbaseAmountAfterCalc1,
+		validatorAmountAfterCalc1,
+		incentivePoolRewardAmountAfterCalc1,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	// error is raised to prevent issuing zero rewards Tx
+	assert.Error(t, err)
+	assert.Equal(t, "no rewards collected", err.Error())
+
+	assert.Equal(t, ZERO, calc2.CoinbaseAmountToSub)
+	assert.Equal(t, ZERO, calc2.ValidatorRewardAmount)
+	assert.Equal(t, ZERO, calc2.IncentivePoolRewardAmount)
+}
+
+func TestRewardCalculationSumOfCalculationsEqualsTotalCalculation(t *testing.T) {
+	feesBurned := CAM1
+	validatorRewards := ZERO
+	incentivePoolRewards := ZERO
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	calc1, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc1 := big.NewInt(0).Sub(feesBurned, calc1.CoinbaseAmountToSub)
+	validatorAmountAfterCalc1 := big.NewInt(0).Add(validatorRewards, calc1.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc1 := big.NewInt(0).Add(incentivePoolRewards, calc1.IncentivePoolRewardAmount)
+
+	total := CAM1
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc1, validatorAmountAfterCalc1, incentivePoolRewardAmountAfterCalc1),
+	)
+	feesBurned = bigAdd(coinbaseAmountAfterCalc1, CAM1)
+	calc2, err := CalculateRewards(
+		feesBurned,
+		validatorAmountAfterCalc1,
+		incentivePoolRewardAmountAfterCalc1,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc2 := big.NewInt(0).Sub(feesBurned, calc2.CoinbaseAmountToSub)
+	validatorAmountAfterCalc2 := bigAdd(validatorAmountAfterCalc1, calc2.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc2 := bigAdd(incentivePoolRewardAmountAfterCalc1, calc2.IncentivePoolRewardAmount)
+
+	total = bigMul(CAM1, 2)
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc2, validatorAmountAfterCalc2, incentivePoolRewardAmountAfterCalc2),
+	)
+
+	feesBurned = bigAdd(coinbaseAmountAfterCalc2, CAM1)
+	calc3, err := CalculateRewards(
+		feesBurned,
+		validatorAmountAfterCalc2,
+		incentivePoolRewardAmountAfterCalc2,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc3 := big.NewInt(0).Sub(feesBurned, calc3.CoinbaseAmountToSub)
+	validatorAmountAfterCalc3 := bigAdd(validatorAmountAfterCalc2, calc3.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc3 := bigAdd(incentivePoolRewardAmountAfterCalc2, calc3.IncentivePoolRewardAmount)
+
+	total = bigMul(CAM1, 3)
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc3, validatorAmountAfterCalc3, incentivePoolRewardAmountAfterCalc3),
+	)
+
+	calcTotal, err := CalculateRewards(
+		bigMul(CAM1, 3),
+		ZERO,
+		ZERO,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, incentivePoolRewardAmountAfterCalc3, validatorAmountAfterCalc3)
+	assert.Equal(t, calcTotal.ValidatorRewardAmount, validatorAmountAfterCalc3)
+	assert.Equal(t, calcTotal.IncentivePoolRewardAmount, incentivePoolRewardAmountAfterCalc3)
+}
+
+func TestRewardCalculationRaiseRateAfterFirstCalculation(t *testing.T) {
+	feesBurned := CAM1
+	validatorRewards := ZERO
+	incentivePoolRewards := ZERO
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	calc1, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc1 := big.NewInt(0).Sub(feesBurned, calc1.CoinbaseAmountToSub)
+	validatorAmountAfterCalc1 := big.NewInt(0).Add(validatorRewards, calc1.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc1 := big.NewInt(0).Add(incentivePoolRewards, calc1.IncentivePoolRewardAmount)
+
+	total := CAM1
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc1, validatorAmountAfterCalc1, incentivePoolRewardAmountAfterCalc1),
+	)
+	feesBurned = bigAdd(coinbaseAmountAfterCalc1, CAM1)
+	feeRewardRate = uint64(0.20 * float64(percentDenominator))
+	incentivePoolRate = uint64(0.20 * float64(percentDenominator))
+	calc2, err := CalculateRewards(
+		feesBurned,
+		validatorAmountAfterCalc1,
+		incentivePoolRewardAmountAfterCalc1,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc2 := big.NewInt(0).Sub(feesBurned, calc2.CoinbaseAmountToSub)
+	validatorAmountAfterCalc2 := bigAdd(validatorAmountAfterCalc1, calc2.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc2 := bigAdd(incentivePoolRewardAmountAfterCalc1, calc2.IncentivePoolRewardAmount)
+
+	total = bigMul(CAM1, 2)
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc2, validatorAmountAfterCalc2, incentivePoolRewardAmountAfterCalc2),
+	)
+
+	calcTotal, err := CalculateRewards(
+		bigMul(CAM1, 2),
+		ZERO,
+		ZERO,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, incentivePoolRewardAmountAfterCalc2, validatorAmountAfterCalc2)
+	assert.Equal(t, calcTotal.ValidatorRewardAmount, validatorAmountAfterCalc2)
+	assert.Equal(t, calcTotal.IncentivePoolRewardAmount, incentivePoolRewardAmountAfterCalc2)
+}
+
+func TestRewardCalculationLowerRateAfterFirstCalculation(t *testing.T) {
+	feesBurned := CAM1
+	validatorRewards := ZERO
+	incentivePoolRewards := ZERO
+	feeRewardRate := uint64(0.20 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.20 * float64(percentDenominator))
+
+	calc1, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc1 := big.NewInt(0).Sub(feesBurned, calc1.CoinbaseAmountToSub)
+	validatorAmountAfterCalc1 := big.NewInt(0).Add(validatorRewards, calc1.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc1 := big.NewInt(0).Add(incentivePoolRewards, calc1.IncentivePoolRewardAmount)
+
+	total := CAM1
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc1, validatorAmountAfterCalc1, incentivePoolRewardAmountAfterCalc1),
+	)
+	feesBurned = bigAdd(coinbaseAmountAfterCalc1, CAM1)
+	feeRewardRate = uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate = uint64(0.10 * float64(percentDenominator))
+	calc2, err := CalculateRewards(
+		feesBurned,
+		validatorAmountAfterCalc1,
+		incentivePoolRewardAmountAfterCalc1,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	// error is raised to prevent issuing zero rewards Tx
+	assert.Error(t, err)
+	assert.Equal(t, "no rewards collected", err.Error())
+
+	coinbaseAmountAfterCalc2 := big.NewInt(0).Sub(feesBurned, calc2.CoinbaseAmountToSub)
+	validatorAmountAfterCalc2 := bigAdd(validatorAmountAfterCalc1, calc2.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc2 := bigAdd(incentivePoolRewardAmountAfterCalc1, calc2.IncentivePoolRewardAmount)
+
+	total = bigMul(CAM1, 2)
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc2, validatorAmountAfterCalc2, incentivePoolRewardAmountAfterCalc2),
+	)
+
+	calcTotal, err := CalculateRewards(
+		bigMul(CAM1, 2),
+		ZERO,
+		ZERO,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, incentivePoolRewardAmountAfterCalc2, validatorAmountAfterCalc2)
+	assert.Equal(t, calcTotal.ValidatorRewardAmount, validatorAmountAfterCalc2)
+	assert.Equal(t, calcTotal.IncentivePoolRewardAmount, incentivePoolRewardAmountAfterCalc2)
+}
+
+func TestRewardCalculationPercentageChangeAfterFirstCalculationAndBackBeforeTotalCalculation(t *testing.T) {
+	feesBurned := CAM1
+	validatorRewards := ZERO
+	incentivePoolRewards := ZERO
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	calc1, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc1 := big.NewInt(0).Sub(feesBurned, calc1.CoinbaseAmountToSub)
+	validatorAmountAfterCalc1 := big.NewInt(0).Add(validatorRewards, calc1.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc1 := big.NewInt(0).Add(incentivePoolRewards, calc1.IncentivePoolRewardAmount)
+
+	total := CAM1
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc1, validatorAmountAfterCalc1, incentivePoolRewardAmountAfterCalc1),
+	)
+	feesBurned = bigAdd(coinbaseAmountAfterCalc1, CAM1)
+
+	feeRewardRate = uint64(0.20 * float64(percentDenominator))
+	incentivePoolRate = uint64(0.20 * float64(percentDenominator))
+	calc2, err := CalculateRewards(
+		feesBurned,
+		validatorAmountAfterCalc1,
+		incentivePoolRewardAmountAfterCalc1,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	coinbaseAmountAfterCalc2 := big.NewInt(0).Sub(feesBurned, calc2.CoinbaseAmountToSub)
+	validatorAmountAfterCalc2 := bigAdd(validatorAmountAfterCalc1, calc2.ValidatorRewardAmount)
+	incentivePoolRewardAmountAfterCalc2 := bigAdd(incentivePoolRewardAmountAfterCalc1, calc2.IncentivePoolRewardAmount)
+
+	total = bigMul(CAM1, 2)
+	assert.Equal(t,
+		total,
+		bigAdd(coinbaseAmountAfterCalc2, validatorAmountAfterCalc2, incentivePoolRewardAmountAfterCalc2),
+	)
+
+	feeRewardRate = uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate = uint64(0.10 * float64(percentDenominator))
+
+	calcTotal, err := CalculateRewards(
+		bigMul(CAM1, 3),
+		ZERO,
+		ZERO,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+	assert.NoError(t, err)
+
+	/*
+		The way calculation is done does not allow to change rates on the go, changing rates requires more work
+		than just changing rate parameters (we need to freeze current state, calculate total on new rate, set all
+		the states to the previous values
+	*/
+	assert.Equal(t, incentivePoolRewardAmountAfterCalc2, validatorAmountAfterCalc2)
+	assert.NotEqual(t, calcTotal.ValidatorRewardAmount, validatorAmountAfterCalc2)
+	assert.NotEqual(t, calcTotal.IncentivePoolRewardAmount, incentivePoolRewardAmountAfterCalc2)
+}
+
+func TestRewardCalculationNegativeBlackHoleAddressBalance(t *testing.T) {
+	feesBurned := big.NewInt(-1)
+	validatorRewards := big.NewInt(0)
+	incentivePoolRewards := big.NewInt(0)
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	_, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, "feesBurned < 0", err.Error())
+}
+
+func TestRewardCalculationNegativePayedOutBalance(t *testing.T) {
+	feesBurned := big.NewInt(1_000_000_000_000_000_000)
+	validatorRewards := big.NewInt(-1)
+	incentivePoolRewards := big.NewInt(0)
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	_, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, "validatorRewards < 0", err.Error())
+}
+
+func TestRewardCalculationNegativeIncentivePoolBalance(t *testing.T) {
+	feesBurned := big.NewInt(1_000_000_000_000_000_000)
+	validatorRewards := big.NewInt(0)
+	incentivePoolRewards := big.NewInt(-1)
+	feeRewardRate := uint64(0.10 * float64(percentDenominator))
+	incentivePoolRate := uint64(0.10 * float64(percentDenominator))
+
+	_, err := CalculateRewards(
+		feesBurned,
+		validatorRewards,
+		incentivePoolRewards,
+		feeRewardRate,
+		incentivePoolRate,
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, "incentivePoolRewards < 0", err.Error())
+}
+
+func bigAdd(ingredients ...*big.Int) *big.Int {
+	sum := big.NewInt(0)
+	for _, ingredient := range ingredients {
+		sum.Add(sum, ingredient)
+	}
+	return sum
+}


### PR DESCRIPTION
This PR implements collection of the rewards from the burned fees. 
**It does not import exported funds into P-chain**. It needs to be done in separate PR.
Solution draft is posted in [TECH-273](https://c4t.atlassian.net/browse/TECH-273)

It extends the genesis and the Block's header of these parameters:

- `FeeRewardMinAmountToExport uint64` - expressed in the P/X-chain precision, minimum amount that needs to be reached to issue the CollectRewardTx
- `FeeRewardRate uint64` - percent of the fees exported as Validator rewards. It is denominated to uint64 from floating point ratio (`ratio * evm.percentDenominator`). E.g. 30% will be expressed as `0.30 * 1_000_000 == 300_000`
- `IncentivePoolRewardRate` - percent of the fees transferred to DApps Incentive Pool. It is denominated to uint64 from floating point ratio (`ratio * evm.percentDenominator`). See 👆. 
- `FeeRewardExportAddress (HEX) string` - P-Chain address bytes as hex to export Validator rewards to
- `IncentivePoolRewardAddress (HEX) string` - IP Contract address (`0x010000000000000000000000000000000000000c`)

This parameters for now are constants - see: [0d4877d](https://github.com/chain4travel/caminoethvm/blob/0d4877d0dea240909855067f319135c17c3f87c6/plugin/evm/collect_rewards_tx.go#L35-L43)

Also make sure the `Sunrise0Phase` is active (set `\"sunrisePhase0BlockTimestamp\":0` in the genesis "config").
SunrisePhase0 is important to set `BlockGasCost` to `0` which **allows the `CollectRewardsTx` to pay no fees**.s

### Testing instructions
- Fund the C-chain account
- Make a transfer (repeat)
- Once the calculated rewards exceeds the minimum amount you shall see the additional block is mined. This block will contain `CollectRewardsTx`.
- Observe that BH (coinbase) address balance has been decreased,
- Check that balance of the DApp's IP contract has been increased,
- Check that new UTXO appeared for `FeeRewardExportAddress` on the P-chain, you can import it via RPC if you set your account address as `FeeRewardExportAddress`.

This truffle's [testing script](https://gist.github.com/pnowosie/b5b32a6bb5acf537e27d46abcc343200) might be handy.

Estimation of the transfer fees depends on the frequency of the transfer Txs - more frequent the more expensive fees.
