### PR TITLE
checking out submodule caminogo from dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "caminogo"]
 	path = caminogo
 	url = https://github.com/chain4travel/caminogo.git
+	branch = dev


### PR DESCRIPTION
This is to checkout submodule caminogo from dev branch.

This shouldn't be merged to chain4travel branch. When everything is ready for merging to c4t branch, this should be reverted.