### PR TITLE
Restrict contract deploy to KYC verified callers

### DIFF
--- a/core/admin/admin.go
+++ b/core/admin/admin.go
@@ -5,13 +5,21 @@ package admin
 import (
 	"math/big"
 
-	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
+	"github.com/ethereum/go-ethereum/common"
 )
+
+type StateDB interface {
+	GetState(common.Address, common.Hash) common.Hash
+}
+
+type EmptyStruct struct{}
 
 // Admin interface to control administrative tasks, which are intended to
 // be controlled on block level like BaseFee or Blacklisting or KYC
 type AdminController interface {
 	// Get the FixedBaseFee which should applied for blocks after height
-	GetFixedBaseFee(head *types.Header, state *state.StateDB) *big.Int
+	GetFixedBaseFee(head *types.Header, state StateDB) *big.Int
+	// Returns true if we are in SunrisePhase0 and KYC flag is set
+	KycVerified(head *types.Header, state StateDB, addr common.Address) bool
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2021, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -36,6 +46,7 @@ import (
 	"github.com/ava-labs/coreth/accounts/abi"
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
@@ -245,6 +256,11 @@ type dummyChain struct {
 
 // Engine retrieves the chain's consensus engine.
 func (d *dummyChain) Engine() consensus.Engine {
+	return nil
+}
+
+// AdminController, not part of the tests
+func (d *dummyChain) AdminController() admin.AdminController {
 	return nil
 }
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -39,6 +49,7 @@ import (
 
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/core/vm"
@@ -74,6 +85,7 @@ const (
 // Backend interface provides the common API services (that are provided by
 // both full and light clients) with access to necessary functions.
 type Backend interface {
+	AdminController() admin.AdminController
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
@@ -105,6 +117,10 @@ type chainContext struct {
 
 func (context *chainContext) Engine() consensus.Engine {
 	return context.api.backend.Engine()
+}
+
+func (context *chainContext) AdminController() admin.AdminController {
+	return context.api.backend.AdminController()
 }
 
 func (context *chainContext) GetHeader(hash common.Hash, number uint64) *types.Header {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -41,6 +51,7 @@ import (
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
@@ -152,6 +163,10 @@ func (b *testBackend) ChainConfig() *params.ChainConfig {
 
 func (b *testBackend) Engine() consensus.Engine {
 	return b.engine
+}
+
+func (b *testBackend) AdminController() admin.AdminController {
+	return nil
 }
 
 func (b *testBackend) ChainDb() ethdb.Database {

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	github.com/supranational/blst v0.3.11-0.20220920110316-f72618070295 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.sum
+++ b/go.sum
@@ -556,8 +556,6 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
-github.com/supranational/blst v0.3.11-0.20220920110316-f72618070295 h1:rVKS9JjtqE4/PscoIsP46sRnJhfq8YFbjlk0fUJTRnY=
-github.com/supranational/blst v0.3.11-0.20220920110316-f72618070295/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/vmerrs/camino_vmerrs.go
+++ b/vmerrs/camino_vmerrs.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+
+package vmerrs
+
+import (
+	"errors"
+)
+
+// List evm execution errors
+var (
+	ErrNotKycVerified = errors.New("not KYC verified")
+)


### PR DESCRIPTION
## KYC restriction for SmartContract deploy

This PR implements the restriction, that smart contracts are only allowed to be deployed for KYC verified addresses.
AdminController is used and KYC state is only checked if we are in SunrisePhase0

The implementation is unoptimized, means that there is no special cache for requesting state.
This should be ok because of limited smart contract deploys in general.

- AdminController is now accessible via Backend()
- If AdminController is instanciated (could be false for e.g. original Testbackends), evm.Create call checks in AdminController::KycVerified, if the user is verified.
- AdminController::KycVerified only checks for validity, if we are in SunrisePhase0 (which is our key for Camino)