### PR TITLE
[REWARDS] Set correct block timestamp in TimedUTXO

### DIFF
--- a/plugin/evm/camino_collect_rewards_tx_test.go
+++ b/plugin/evm/camino_collect_rewards_tx_test.go
@@ -173,14 +173,6 @@ func TestCollectRewardsSemanticVerify(t *testing.T) {
 			expectedTxError:    errors.New("input has no value"),
 		},
 		{
-			name:                 "Tx and block time mismatch",
-			amountToDistribute:   amount,
-			txBlockTime:          1000,
-			blockTime:            900,
-			timestampSlot:        1200,
-			expectedInvalidError: errors.New("invalid block time"),
-		},
-		{
 			name:                 "Time has not passed",
 			amountToDistribute:   amount,
 			txBlockTime:          1675080000,


### PR DESCRIPTION
## Why this should be merged
Currently the block timestamp in RewardValTx is modulo'ed by TimeInterval.
This leads to TimedUTXO's in sharedmem with an older timeStamp as expected and leads to immediate import on P-chain.
## How this works
With this PR we write the correct block timestamp into TX and UTXO's and handle modulo things on demand.
