### PR TITLE
Peak3d/admin

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ava-labs/coreth/accounts/abi/bind"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/core/bloombits"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
@@ -106,7 +107,7 @@ type SimulatedBackend struct {
 // NewSimulatedBackendWithDatabase creates a new binding backend based on the given database
 // and uses a simulated blockchain for testing purposes.
 // A simulated backend always uses chainID 1337.
-func NewSimulatedBackendWithDatabase(database ethdb.Database, alloc core.GenesisAlloc, gasLimit uint64, addr common.Address) *SimulatedBackend {
+func NewSimulatedBackendWithDatabase(database ethdb.Database, alloc core.GenesisAlloc, gasLimit uint64, addr common.Address, ctrl admin.AdminController) *SimulatedBackend {
 	cpcfg := params.TestChainConfig
 	cpcfg.ChainID = big.NewInt(1337)
 	genesis := core.Genesis{Config: cpcfg, GasLimit: gasLimit, Alloc: alloc, InitialAdmin: addr}
@@ -115,7 +116,8 @@ func NewSimulatedBackendWithDatabase(database ethdb.Database, alloc core.Genesis
 	}
 	genesis.MustCommit(database)
 	cacheConfig := &core.CacheConfig{}
-	blockchain, _ := core.NewBlockChain(database, cacheConfig, genesis.Config, dummy.NewFaker(), vm.Config{}, common.Hash{})
+
+	blockchain, _ := core.NewBlockChain(database, cacheConfig, genesis.Config, dummy.NewFaker(), vm.Config{AdminContoller: ctrl}, common.Hash{})
 
 	backend := &SimulatedBackend{
 		database:   database,
@@ -135,14 +137,21 @@ func NewSimulatedBackendWithDatabase(database ethdb.Database, alloc core.Genesis
 // for testing purposes.
 // A simulated backend always uses chainID 1337.
 func NewSimulatedBackend(alloc core.GenesisAlloc, gasLimit uint64) *SimulatedBackend {
-	return NewSimulatedBackendWithDatabase(rawdb.NewMemoryDatabase(), alloc, gasLimit, common.Address{})
+	return NewSimulatedBackendWithDatabase(rawdb.NewMemoryDatabase(), alloc, gasLimit, common.Address{}, nil)
 }
 
 // NewSimulatedBackendWithInitialAdmin creates a new binding backend using a simulated blockchain
 // for testing purposes.
 // A simulated backend always uses chainID 1337.
 func NewSimulatedBackendWithInitialAdmin(alloc core.GenesisAlloc, gasLimit uint64, addr common.Address) *SimulatedBackend {
-	return NewSimulatedBackendWithDatabase(rawdb.NewMemoryDatabase(), alloc, gasLimit, addr)
+	return NewSimulatedBackendWithDatabase(rawdb.NewMemoryDatabase(), alloc, gasLimit, addr, nil)
+}
+
+// NewSimulatedBackendWithInitialAdmin creates a new binding backend using a simulated blockchain
+// for testing purposes.
+// A simulated backend always uses chainID 1337.
+func NewSimulatedBackendWithInitialAdminAndAdminController(alloc core.GenesisAlloc, gasLimit uint64, addr common.Address, ctrl admin.AdminController) *SimulatedBackend {
+	return NewSimulatedBackendWithDatabase(rawdb.NewMemoryDatabase(), alloc, gasLimit, addr, ctrl)
 }
 
 // Close terminates the underlying blockchain's update loop.

--- a/core/admin/admin.go
+++ b/core/admin/admin.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 
 package admin
 
@@ -18,6 +18,8 @@ type EmptyStruct struct{}
 // Admin interface to control administrative tasks, which are intended to
 // be controlled on block level like BaseFee or Blacklisting or KYC
 type AdminController interface {
+	// Starts listening to blockchain events
+	Start()
 	// Get the FixedBaseFee which should applied for blocks after height
 	GetFixedBaseFee(head *types.Header, state StateDB) *big.Int
 	// Returns true if we are in SunrisePhase0 and KYC flag is set

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.
@@ -307,6 +307,7 @@ func NewBlockChain(
 	bc := &BlockChain{
 		chainConfig: chainConfig,
 		cacheConfig: cacheConfig,
+		adminCtrl:   vmConfig.AdminContoller,
 		db:          db,
 		stateCache: state.NewDatabaseWithConfig(db, &trie.Config{
 			Cache:       cacheConfig.TrieCleanLimit,
@@ -656,11 +657,6 @@ func (bc *BlockChain) stopAcceptor() {
 	bc.acceptorWg.Wait()
 	bc.acceptorClosed = true
 	close(bc.acceptorQueue)
-}
-
-// SetAdminController sets the admin Controller.
-func (bc *BlockChain) SetAdminController(ctrl admin.AdminController) {
-	bc.adminCtrl = ctrl
 }
 
 func (bc *BlockChain) InitializeSnapshots() {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2019-2020, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
@@ -29,6 +39,7 @@ package vm
 import (
 	"hash"
 
+	"github.com/ava-labs/coreth/core/admin"
 	"github.com/ava-labs/coreth/vmerrs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -55,6 +66,9 @@ type Config struct {
 
 	// AllowUnfinalizedQueries allow unfinalized queries
 	AllowUnfinalizedQueries bool
+
+	// Admincontoller interface
+	AdminContoller admin.AdminController
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
## Why this should be merged
There is still a situation on start of a node where a TX is processed before AdminController is properly initialized.
This leads to Gas mismatch errors on block processing, because absense of AdminController == KYC verified.

## How this works
AdminController is now instanciated before blockchain initialization and passed in VMConfig so blockchain can securely setup AdminController before it starts processing outstanding requests.
To avoid Chicken Egg issues the AdminController BlockEventListener is started after blockchain initialization is done.

## How this was tested
Test on broken Beacon kopernikus chain / Unit tests