### PR TITLE
[MULTISIG] Storing Alias definitions in Smart Contract state

### DIFF
--- a/contracts/camino_smart_contracts.go
+++ b/contracts/camino_smart_contracts.go
@@ -1,0 +1,17 @@
+package contracts
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func NextSlot(addr common.Hash) common.Hash {
+	bigAddr := new(big.Int).Add(addr.Big(), common.Big1)
+	return common.BigToHash(bigAddr)
+}
+
+func EntryAddress(address common.Address, slot int64) common.Hash {
+	return crypto.Keccak256Hash(address.Hash().Bytes(), common.BigToHash(big.NewInt(slot)).Bytes())
+}

--- a/contracts/camino_smart_contracts_test.go
+++ b/contracts/camino_smart_contracts_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/coreth/accounts/abi/bind/backends"
 	"github.com/ava-labs/coreth/accounts/keystore"
 	"github.com/ava-labs/coreth/consensus/dummy"
+	admin "github.com/ava-labs/coreth/contracts/build_contracts/admin/src"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/state"
@@ -32,7 +33,7 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/vmerrs"
 
-	admin "github.com/ava-labs/coreth/contracts/build_contracts/admin/src"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -686,4 +687,26 @@ func addAndVerifyRoles(t *testing.T, adminSession admin.BuildSession, sim *backe
 	roles = append(roles, blacklistRole)
 
 	return roles
+}
+
+func TestStorageSlotIndices(t *testing.T) {
+	// See article about storing solidity structures https://c4t.atlassian.net/wiki/spaces/TECH/pages/315228161/Extending+Multisig+support+to+other+chains+X+C
+	const (
+		expectedAliasThresholdSlot         = "0x02d8eabfe500216f0da458b4ce6732047b68f7e037b3e2d7313765a12e1ff7fc"
+		expectedAliasCGroupArrayLengthSlot = "0x02d8eabfe500216f0da458b4ce6732047b68f7e037b3e2d7313765a12e1ff7fd"
+		expectedAliasCGroupArraySlot       = "0xba536a6eed5d97c805d767eb1aaffd73a6446dbca7494685f2c6f3bdc1fd2777"
+	)
+	var (
+		aliasAdddress       = common.HexToAddress("0x010000000000000000000000000000000000000e")
+		contractMappingSlot = int64(0)
+	)
+
+	aliasThresholdSlot := EntryAddress(aliasAdddress, contractMappingSlot)
+	require.Equal(t, expectedAliasThresholdSlot, aliasThresholdSlot.String())
+
+	aliasArrayLenSlot := NextSlot(aliasThresholdSlot)
+	require.Equal(t, expectedAliasCGroupArrayLengthSlot, aliasArrayLenSlot.String())
+
+	aliasArrauSlot := crypto.Keccak256Hash(aliasArrayLenSlot.Bytes())
+	require.Equal(t, expectedAliasCGroupArraySlot, aliasArrauSlot.String())
 }

--- a/plugin/evm/import_tx_test.go
+++ b/plugin/evm/import_tx_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ava-labs/coreth/contracts"
 	"github.com/ava-labs/coreth/params"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
@@ -21,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 // createImportTxOptions adds a UTXO to shared memory and generates a list of import transactions sending this UTXO
@@ -1375,6 +1377,103 @@ func TestImportTxEVMStateTransfer(t *testing.T) {
 				avaxBalance := sdb.GetBalance(testEthAddrs[0])
 				if avaxBalance.Cmp(common.Big0) != 0 {
 					t.Fatalf("Expected AVAX balance to be 0, found balance: %d", avaxBalance)
+				}
+			},
+		},
+		"Multisig UTXO": {
+			setup: func(t *testing.T, vm *VM, sharedMemory *atomic.Memory) *Tx {
+				txID := ids.GenerateTestID()
+				amount := uint64(3)
+				aliasID := ids.ShortID{1, 2, 3, 4, 5}
+				memberAddr := testKeys[0].Address()
+				msigAlias := &multisig.AliasWithNonce{
+					Alias: multisig.Alias{
+						ID: aliasID,
+						Owners: &secp256k1fx.OutputOwners{
+							Threshold: 1,
+							Addrs:     []ids.ShortID{memberAddr},
+						},
+					},
+				}
+				utxo := &avax.UTXOWithMSig{
+					UTXO: avax.UTXO{
+						UTXOID: avax.UTXOID{
+							TxID:        txID,
+							OutputIndex: 0,
+						},
+						Asset: avax.Asset{ID: vm.ctx.AVAXAssetID},
+						Out: &secp256k1fx.TransferOutput{
+							Amt: amount,
+							OutputOwners: secp256k1fx.OutputOwners{
+								Threshold: 1,
+								Addrs:     []ids.ShortID{aliasID},
+							},
+						},
+					},
+					Aliases: []verify.State{msigAlias},
+				}
+				err := putUTXOToSharedMemory(sharedMemory, vm.ctx.XChainID, vm.ctx.ChainID, [][]byte{}, utxo)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				tx := &Tx{UnsignedAtomicTx: &UnsignedImportTx{
+					NetworkID:    vm.ctx.NetworkID,
+					BlockchainID: vm.ctx.ChainID,
+					SourceChain:  vm.ctx.XChainID,
+					ImportedInputs: []*avax.TransferableInput{{
+						UTXOID: utxo.UTXOID,
+						Asset:  avax.Asset{ID: vm.ctx.AVAXAssetID},
+						In: &secp256k1fx.TransferInput{
+							Amt:   amount,
+							Input: secp256k1fx.Input{SigIndices: []uint32{0}},
+						},
+					}},
+					Outs: []EVMOutput{{
+						Address: testEthAddrs[0],
+						Amount:  amount,
+						AssetID: vm.ctx.AVAXAssetID,
+					}},
+				}}
+				if err := tx.Sign(vm.codec, [][]*crypto.PrivateKeySECP256K1R{{testKeys[0]}}); err != nil {
+					t.Fatal(err)
+				}
+				return tx
+			},
+			checkState: func(t *testing.T, vm *VM) {
+				msigContractAddress := common.HexToAddress("0x010000000000000000000000000000000000000e")
+				aliasAddress := common.HexToAddress("0x0102030405000000000000000000000000000000")
+				lastAcceptedBlock := vm.LastAcceptedBlockInternal().(*Block)
+
+				sdb, err := vm.blockChain.StateAt(lastAcceptedBlock.ethBlock.Root())
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				avaxBalance := sdb.GetBalance(testEthAddrs[0])
+				expectedBalance := new(big.Int).Mul(big.NewInt( /*amount=*/ 3), x2cRate)
+
+				if avaxBalance.Cmp(expectedBalance) != 0 {
+					t.Fatalf("Expected AVAX balance to be %d, found balance: %d", x2cRate, avaxBalance)
+				}
+
+				// check multisig alias is stored in the SC's state
+				aliasSlot := contracts.EntryAddress(aliasAddress, 0)
+				threshold := sdb.GetState(msigContractAddress, aliasSlot).Big()
+				if threshold.Cmp(common.Big1) != 0 {
+					t.Fatalf("Expected threshold to be 1, found: %d", threshold)
+				}
+				lenSlot := contracts.NextSlot(aliasSlot)
+				length := sdb.GetState(msigContractAddress, lenSlot).Big()
+				if length.Cmp(common.Big1) != 0 {
+					t.Fatalf("Expected length to be 1, found: %d", length)
+				}
+
+				addressSlot := ethCrypto.Keccak256Hash(lenSlot.Bytes())
+				address := common.BytesToAddress(sdb.GetState(msigContractAddress, addressSlot).Bytes())
+				expectedMemberAddress := common.BytesToAddress(testKeys[0].Address().Bytes())
+				if expectedMemberAddress != address {
+					t.Fatalf("Expected member address to be %s, found: %s", expectedMemberAddress, address)
 				}
 			},
 		},


### PR DESCRIPTION
## Why this should be merged

PR adds exported MultisigAliases (from ShM along with UTXOs, see: #65, [#caminogo/217](https://github.com/chain4travel/caminogo/pull/217)) to MultisigAlias contract's state

## How this works

How to store solidity structures from the Go code is explained in the [article](https://c4t.atlassian.net/wiki/spaces/TECH/pages/315228161/Extending+Multisig+support+to+other+chains+X+C)

## How this was tested

Unit test