### PR TITLE
Cortina 10: Ava-labs/core-eth v0.12.5-rc6 (avalanchego 1.10.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19.12'
+          go-version: '~1.20.8'
           check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -65,7 +65,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19.12'
+        go-version: '~1.20.8'
         check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -98,7 +98,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19.12'
+        go-version: '~1.20.8'
         check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -129,7 +129,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19.12'
+        go-version: '~1.20.8'
         check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -166,7 +166,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19.12'
+        go-version: '~1.20.8'
         check-latest: true
     - name: Run e2e tests
       run: E2E_SERIAL=1 ./scripts/tests.e2e.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,26 @@ jobs:
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         KURTOSIS_CLIENT_ID: ${{ secrets.KURTOSIS_CLIENT_ID }}
         KURTOSIS_CLIENT_SECRET: ${{ secrets.KURTOSIS_CLIENT_SECRET }}
+  avalanchego_e2e:
+    name: AvalancheGo E2E Tests v${{ matrix.go }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.avalanchegoRepo }}
+        ref: ${{ github.event.inputs.avalanchegoBranch }}
+        path: avalanchego
+        token: ${{ secrets.AVALANCHE_PAT }}
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '~1.19.12'
+        check-latest: true
+    - name: Run e2e tests
+      run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: '~1.19.12'
+          check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -51,7 +52,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -65,7 +65,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
@@ -84,7 +85,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v3
@@ -98,7 +98,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
@@ -115,7 +116,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.19' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3
@@ -129,7 +129,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.19'
+        go-version: '~1.20.8'
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |
@@ -58,7 +58,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
     - name: check out
@@ -78,7 +77,8 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.20.8'
+        check-latest: true
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |
@@ -97,7 +97,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
         os: [ubuntu-20.04]
     steps:
     - name: check out
@@ -118,7 +117,8 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.20.8'
+        check-latest: true
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
           path: caminogo
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: change caminogo dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
+        go: ['1.20']
         os: [macos-11.0, ubuntu-18.04, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
+        go: ['1.20']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v3
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.20' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ awscpu
 
 bin/
 build/
+
+# Used for e2e testing
+avalanchego

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file configures github.com/golangci/golangci-lint.
 
 run:
-  timeout: 3m
+  timeout: 10m
   tests: true
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ============= Compilation Stage ================
-FROM golang:1.19.12-bullseye AS builder
+FROM golang:1.20.8-bullseye AS builder
 
 ARG AVALANCHE_VERSION
 
@@ -17,7 +17,7 @@ WORKDIR $GOPATH/src/github.com/ava-labs/avalanchego
 RUN go mod download
 # Replace the coreth dependency
 RUN go mod edit -replace github.com/ava-labs/coreth=../coreth
-RUN go mod download && go mod tidy -compat=1.19
+RUN go mod download && go mod tidy -compat=1.20
 
 # Build the AvalancheGo binary with local version of coreth.
 RUN ./scripts/build_avalanche.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # ============= Compilation Stage ================
-FROM golang:1.19.10-buster AS builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
+FROM golang:1.19.12-bullseye AS builder
 
 ARG AVALANCHE_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # ============= Compilation Stage ================
-FROM golang:1.19.10-buster AS builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
+FROM golang:1.20.8-bullseye AS builder
 
 ARG CAMINO_VERSION
 
@@ -19,7 +17,7 @@ WORKDIR $GOPATH/src/github.com/chain4travel/caminogo
 RUN go mod download
 # Replace the coreth dependency
 RUN go mod edit -replace github.com/ava-labs/coreth=../caminoethvm
-RUN go mod download && go mod tidy -compat=1.18
+RUN go mod download && go mod tidy -compat=1.20
 
 # Build the CaminoGo binary with local version of caminoethvm.
 RUN ./scripts/build_camino.sh

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2189,7 +2189,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.18")
+	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.19")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {
 		t.Fatalf("failed to tidy Go module file: %v\n%s", err, out)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -634,7 +634,7 @@ func diffToDisk(bottom *diffLayer) (*diskLayer, bool, error) {
 			// Ensure we don't delete too much data blindly (contract can be
 			// huge). It's ok to flush, the root will go missing in case of a
 			// crash and we'll detect and regenerate the snapshot.
-			if batch.ValueSize() > ethdb.IdealBatchSize {
+			if batch.ValueSize() > 64*1024*1024 {
 				if err := batch.Write(); err != nil {
 					log.Crit("Failed to write storage deletions", "err", err)
 				}
@@ -660,7 +660,7 @@ func diffToDisk(bottom *diffLayer) (*diskLayer, bool, error) {
 		// Ensure we don't write too much data blindly. It's ok to flush, the
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
-		if batch.ValueSize() > ethdb.IdealBatchSize {
+		if batch.ValueSize() > 64*1024*1024 {
 			if err := batch.Write(); err != nil {
 				log.Crit("Failed to write storage deletions", "err", err)
 			}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -630,6 +630,21 @@ func (pool *TxPool) PendingSize() int {
 	return count
 }
 
+// IteratePending iterates over [pool.pending] until [f] returns false.
+// The caller must not modify [tx].
+func (pool *TxPool) IteratePending(f func(tx *types.Transaction) bool) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	for _, list := range pool.pending {
+		for _, tx := range list.txs.items {
+			if !f(tx) {
+				return
+			}
+		}
+	}
+}
+
 // Locals retrieves the accounts currently considered local by the pool.
 func (pool *TxPool) Locals() []common.Address {
 	pool.mu.Lock()

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -645,6 +645,21 @@ func (pool *TxPool) PendingSize() int {
 	return count
 }
 
+// IteratePending iterates over [pool.pending] until [f] returns false.
+// The caller must not modify [tx].
+func (pool *TxPool) IteratePending(f func(tx *types.Transaction) bool) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	for _, list := range pool.pending {
+		for _, tx := range list.txs.items {
+			if !f(tx) {
+				return
+			}
+		}
+	}
+}
+
 // Locals retrieves the accounts currently considered local by the pool.
 func (pool *TxPool) Locals() []common.Address {
 	pool.mu.Lock()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.10-rc.2
+	github.com/ava-labs/avalanchego v1.10.10-rc.4
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/ava-labs/coreth
 
-go 1.19
+go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.9-rc.4
+	github.com/ava-labs/avalanchego v1.10.10-rc.2
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -38,12 +38,14 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa
 	go.uber.org/goleak v1.2.1
+	go.uber.org/mock v0.2.0
 	golang.org/x/crypto v0.1.0
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.8.0
 	golang.org/x/text v0.8.0
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
+	google.golang.org/protobuf v1.30.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
@@ -126,7 +128,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.11.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/mock v0.2.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
@@ -134,7 +135,6 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/ava-labs/coreth
 
-go 1.19
+go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.9-rc.4
+	github.com/ava-labs/avalanchego v1.10.10-rc.4
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1
@@ -38,12 +38,14 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa
 	go.uber.org/goleak v1.2.1
+	go.uber.org/mock v0.2.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.11.0
 	golang.org/x/text v0.12.0
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
+	google.golang.org/protobuf v1.30.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
@@ -75,7 +77,6 @@ require (
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
@@ -134,7 +135,6 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -142,6 +142,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.1.8-rc0
+replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.1.10-rc0
 
 replace github.com/ava-labs/avalanche-ledger-go => github.com/chain4travel/camino-ledger-go v0.0.13-c4t

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.10-rc.1 h1:dPJISEWqL3tdUShe6RuB8CFuXl3rsH8617sXbLBjkIE=
-github.com/ava-labs/avalanchego v1.10.10-rc.1/go.mod h1:C8R5uiltpc8MQ62ixxgODR+15mesWF0aAw3H+Qrl9Iw=
 github.com/ava-labs/avalanchego v1.10.10-rc.2 h1:nlHc1JwKb5TEc9oqPU2exvOpazhxr11N2ym/LzYxv4k=
 github.com/ava-labs/avalanchego v1.10.10-rc.2/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.10.9-rc.4 h1:vtavPfRiF6r1Zc6RV8/arEfVpe9GQsLWHbMfIWkHbMI=
 github.com/ava-labs/avalanchego v1.10.9-rc.4/go.mod h1:vTBLl1zK36olfLRA7IUfdbvphWqlkuarIoXxvZTHZVw=
+github.com/ava-labs/avalanchego v1.10.9 h1:qxhp3YoD2Wm/iIKP6Wb1isbkUPWmIrJxWgivDoL0obM=
+github.com/ava-labs/avalanchego v1.10.9/go.mod h1:C8R5uiltpc8MQ62ixxgODR+15mesWF0aAw3H+Qrl9Iw=
+github.com/ava-labs/avalanchego v1.10.10-rc.2 h1:nlHc1JwKb5TEc9oqPU2exvOpazhxr11N2ym/LzYxv4k=
+github.com/ava-labs/avalanchego v1.10.10-rc.2/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.10-rc.2 h1:nlHc1JwKb5TEc9oqPU2exvOpazhxr11N2ym/LzYxv4k=
-github.com/ava-labs/avalanchego v1.10.10-rc.2/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
+github.com/ava-labs/avalanchego v1.10.10-rc.4 h1:1oxQf1boQDliJspfGBqsYsqg91d4F3qiFTnwnp+EruY=
+github.com/ava-labs/avalanchego v1.10.10-rc.4/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.9-rc.4 h1:vtavPfRiF6r1Zc6RV8/arEfVpe9GQsLWHbMfIWkHbMI=
-github.com/ava-labs/avalanchego v1.10.9-rc.4/go.mod h1:vTBLl1zK36olfLRA7IUfdbvphWqlkuarIoXxvZTHZVw=
-github.com/ava-labs/avalanchego v1.10.9 h1:qxhp3YoD2Wm/iIKP6Wb1isbkUPWmIrJxWgivDoL0obM=
-github.com/ava-labs/avalanchego v1.10.9/go.mod h1:C8R5uiltpc8MQ62ixxgODR+15mesWF0aAw3H+Qrl9Iw=
+github.com/ava-labs/avalanchego v1.10.10-rc.1 h1:dPJISEWqL3tdUShe6RuB8CFuXl3rsH8617sXbLBjkIE=
+github.com/ava-labs/avalanchego v1.10.10-rc.1/go.mod h1:C8R5uiltpc8MQ62ixxgODR+15mesWF0aAw3H+Qrl9Iw=
 github.com/ava-labs/avalanchego v1.10.10-rc.2 h1:nlHc1JwKb5TEc9oqPU2exvOpazhxr11N2ym/LzYxv4k=
 github.com/ava-labs/avalanchego v1.10.10-rc.2/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminogo v1.1.8-rc0 h1:kdQ4mTTLCGsa/sFwqPbMk3gWkCHajHLa8Oz6lwCw+og=
-github.com/chain4travel/caminogo v1.1.8-rc0/go.mod h1:d68dDU47zGRZP99+CfvTLV9rpfDAcd/N0d5QtffizhU=
+github.com/chain4travel/caminogo v1.1.10-rc0 h1:EFGd5vE8Vjej3ADmnBJKYl5oRn1zoAur7cyw5rzkI4A=
+github.com/chain4travel/caminogo v1.1.10-rc0/go.mod h1:ViH6jEHhECl2FM/SoQbUoV/MPrAuE6dBBwlo9KDzr2s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -251,8 +251,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -631,6 +629,8 @@ go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/mock v0.2.0 h1:TaP3xedm7JaAgScZO7tlvlKrqT0p7I6OsdGB5YNSMDU=
+go.uber.org/mock v0.2.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
@@ -907,7 +907,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/peer/network.go
+++ b/peer/network.go
@@ -175,6 +175,7 @@ func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 // Assumes write lock is held
 func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
 	if n.closed.Get() {
+		n.activeAppRequests.Release(1)
 		return nil
 	}
 
@@ -212,6 +213,7 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 	defer n.lock.Unlock()
 
 	if n.closed.Get() {
+		n.activeCrossChainRequests.Release(1)
 		return nil
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
@@ -87,6 +88,7 @@ type network struct {
 	outstandingRequestHandlers map[uint32]message.ResponseHandler // maps avalanchego requestID => message.ResponseHandler
 	activeAppRequests          *semaphore.Weighted                // controls maximum number of active outbound requests
 	activeCrossChainRequests   *semaphore.Weighted                // controls maximum number of active outbound cross chain requests
+	router                     *p2p.Router                        // handles messages being sent to the generic networking SDK
 	appSender                  common.AppSender                   // avalanchego AppSender for sending messages
 	codec                      codec.Manager                      // Codec used for parsing messages
 	crossChainCodec            codec.Manager                      // Codec used for parsing cross chain messages
@@ -99,11 +101,18 @@ type network struct {
 
 	// Set to true when Shutdown is called, after which all operations on this
 	// struct are no-ops.
+	//
+	// Invariant: Even though `closed` is an atomic, `lock` is required to be
+	// held when sending requests to guarantee that the network isn't closed
+	// during these calls. This is because closing the network cancels all
+	// outstanding requests, which means we must guarantee never to register a
+	// request that will never be fulfilled or cancelled.
 	closed utils.Atomic[bool]
 }
 
-func NewNetwork(appSender common.AppSender, codec codec.Manager, crossChainCodec codec.Manager, self ids.NodeID, maxActiveAppRequests int64, maxActiveCrossChainRequests int64) Network {
+func NewNetwork(router *p2p.Router, appSender common.AppSender, codec codec.Manager, crossChainCodec codec.Manager, self ids.NodeID, maxActiveAppRequests int64, maxActiveCrossChainRequests int64) Network {
 	return &network{
+		router:                     router,
 		appSender:                  appSender,
 		codec:                      codec,
 		crossChainCodec:            crossChainCodec,
@@ -172,10 +181,7 @@ func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 	log.Debug("sending request to peer", "nodeID", nodeID, "requestLen", len(request))
 	n.peers.TrackPeer(nodeID)
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = responseHandler
 
 	nodeIDs := set.NewSet[ids.NodeID](1)
@@ -209,10 +215,7 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 		return nil
 	}
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = handler
 
 	// Send cross chain request to [chainID].
@@ -272,19 +275,12 @@ func (n *network) CrossChainAppRequest(ctx context.Context, requestingChainID id
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChainID ids.ID, requestID uint32) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
 	log.Debug("received CrossChainAppRequestFailed from chain", "respondingChainID", respondingChainID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
 		return nil
 	}
 
@@ -299,19 +295,12 @@ func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChai
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppResponse(ctx context.Context, respondingChainID ids.ID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
 	log.Debug("received CrossChainAppResponse from responding chain", "respondingChainID", respondingChainID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
 		return nil
 	}
 
@@ -335,8 +324,8 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	var req message.Request
 	if _, err := n.codec.Unmarshal(request, &req); err != nil {
-		log.Debug("failed to unmarshal app request", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
-		return nil
+		log.Debug("forwarding AppRequest to SDK router", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
+		return n.router.AppRequest(ctx, nodeID, requestID, deadline, request)
 	}
 
 	bufferedDeadline, err := calculateTimeUntilDeadline(deadline, n.appStats)
@@ -366,21 +355,13 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 // Error returned by this function is expected to be treated as fatal by the engine
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
-func (n *network) AppResponse(_ context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
+func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
 	log.Debug("received AppResponse from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received AppResponse to unknown request", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
-		return nil
+		log.Debug("forwarding AppResponse to SDK router", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
+		return n.router.AppResponse(ctx, nodeID, requestID, response)
 	}
 
 	// We must release the slot
@@ -395,21 +376,13 @@ func (n *network) AppResponse(_ context.Context, nodeID ids.NodeID, requestID ui
 // - request times out before a response is provided
 // error returned by this function is expected to be treated as fatal by the engine
 // returns error only when the response handler returns an error
-func (n *network) AppRequestFailed(_ context.Context, nodeID ids.NodeID, requestID uint32) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
+func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
 	log.Debug("received AppRequestFailed from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received AppRequestFailed to unknown request", "nodeID", nodeID, "requestID", requestID)
-		return nil
+		log.Debug("forwarding AppRequestFailed to SDK router", "nodeID", nodeID, "requestID", requestID)
+		return n.router.AppRequestFailed(ctx, nodeID, requestID)
 	}
 
 	// We must release the slot
@@ -442,8 +415,11 @@ func calculateTimeUntilDeadline(deadline time.Time, stats stats.RequestHandlerSt
 
 // markRequestFulfilled fetches the handler for [requestID] and marks the request with [requestID] as having been fulfilled.
 // This is called by either [AppResponse] or [AppRequestFailed].
-// Assumes that the write lock is held.
+// Assumes that the write lock is not held.
 func (n *network) markRequestFulfilled(requestID uint32) (message.ResponseHandler, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	handler, exists := n.outstandingRequestHandlers[requestID]
 	if !exists {
 		return nil, false
@@ -467,10 +443,6 @@ func (n *network) Gossip(gossip []byte) error {
 // error returned by this function is expected to be treated as fatal by the engine
 // returns error if request could not be parsed as message.Request or when the requestHandler returns an error
 func (n *network) AppGossip(_ context.Context, nodeID ids.NodeID, gossipBytes []byte) error {
-	if n.closed.Get() {
-		return nil
-	}
-
 	var gossipMsg message.GossipMessage
 	if _, err := n.codec.Unmarshal(gossipBytes, &gossipMsg); err != nil {
 		log.Debug("could not parse app gossip", "nodeID", nodeID, "gossipLen", len(gossipBytes), "err", err)
@@ -563,4 +535,16 @@ func (n *network) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {
 	defer n.lock.Unlock()
 
 	n.peers.TrackBandwidth(nodeID, bandwidth)
+}
+
+// invariant: peer/network must use explicitly even request ids.
+// for this reason, [n.requestID] is initialized as zero and incremented by 2.
+// This is for backwards-compatibility while the SDK router exists with the
+// legacy coreth handlers to avoid a (very) narrow edge case where request ids
+// can overlap, resulting in a dropped timeout.
+func (n *network) nextRequestID() uint32 {
+	next := n.requestIDGen
+	n.requestIDGen += 2
+
+	return next
 }

--- a/peer/network.go
+++ b/peer/network.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
@@ -90,6 +91,7 @@ type network struct {
 	outstandingRequestHandlers map[uint32]message.ResponseHandler // maps avalanchego requestID => message.ResponseHandler
 	activeAppRequests          *semaphore.Weighted                // controls maximum number of active outbound requests
 	activeCrossChainRequests   *semaphore.Weighted                // controls maximum number of active outbound cross chain requests
+	router                     *p2p.Router                        // handles messages being sent to the generic networking SDK
 	appSender                  common.AppSender                   // avalanchego AppSender for sending messages
 	codec                      codec.Manager                      // Codec used for parsing messages
 	crossChainCodec            codec.Manager                      // Codec used for parsing cross chain messages
@@ -102,11 +104,18 @@ type network struct {
 
 	// Set to true when Shutdown is called, after which all operations on this
 	// struct are no-ops.
+	//
+	// Invariant: Even though `closed` is an atomic, `lock` is required to be
+	// held when sending requests to guarantee that the network isn't closed
+	// during these calls. This is because closing the network cancels all
+	// outstanding requests, which means we must guarantee never to register a
+	// request that will never be fulfilled or cancelled.
 	closed utils.Atomic[bool]
 }
 
-func NewNetwork(appSender common.AppSender, codec codec.Manager, crossChainCodec codec.Manager, self ids.NodeID, maxActiveAppRequests int64, maxActiveCrossChainRequests int64) Network {
+func NewNetwork(router *p2p.Router, appSender common.AppSender, codec codec.Manager, crossChainCodec codec.Manager, self ids.NodeID, maxActiveAppRequests int64, maxActiveCrossChainRequests int64) Network {
 	return &network{
+		router:                     router,
 		appSender:                  appSender,
 		codec:                      codec,
 		crossChainCodec:            crossChainCodec,
@@ -169,16 +178,14 @@ func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 // Assumes write lock is held
 func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
 	if n.closed.Get() {
+		n.activeAppRequests.Release(1)
 		return nil
 	}
 
 	log.Debug("sending request to peer", "nodeID", nodeID, "requestLen", len(request))
 	n.peers.TrackPeer(nodeID)
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = responseHandler
 
 	nodeIDs := set.NewSet[ids.NodeID](1)
@@ -209,13 +216,11 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 	defer n.lock.Unlock()
 
 	if n.closed.Get() {
+		n.activeCrossChainRequests.Release(1)
 		return nil
 	}
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = handler
 
 	// Send cross chain request to [chainID].
@@ -275,19 +280,12 @@ func (n *network) CrossChainAppRequest(ctx context.Context, requestingChainID id
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChainID ids.ID, requestID uint32) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
 	log.Debug("received CrossChainAppRequestFailed from chain", "respondingChainID", respondingChainID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
 		return nil
 	}
 
@@ -302,19 +300,12 @@ func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChai
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppResponse(ctx context.Context, respondingChainID ids.ID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
 	log.Debug("received CrossChainAppResponse from responding chain", "respondingChainID", respondingChainID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
 		return nil
 	}
 
@@ -338,8 +329,8 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	var req message.Request
 	if _, err := n.codec.Unmarshal(request, &req); err != nil {
-		log.Debug("failed to unmarshal app request", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
-		return nil
+		log.Debug("forwarding AppRequest to SDK router", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
+		return n.router.AppRequest(ctx, nodeID, requestID, deadline, request)
 	}
 
 	bufferedDeadline, err := calculateTimeUntilDeadline(deadline, n.appStats)
@@ -369,21 +360,13 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 // Error returned by this function is expected to be treated as fatal by the engine
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
-func (n *network) AppResponse(_ context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
+func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
 	log.Debug("received AppResponse from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received AppResponse to unknown request", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
-		return nil
+		log.Debug("forwarding AppResponse to SDK router", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
+		return n.router.AppResponse(ctx, nodeID, requestID, response)
 	}
 
 	// We must release the slot
@@ -398,21 +381,13 @@ func (n *network) AppResponse(_ context.Context, nodeID ids.NodeID, requestID ui
 // - request times out before a response is provided
 // error returned by this function is expected to be treated as fatal by the engine
 // returns error only when the response handler returns an error
-func (n *network) AppRequestFailed(_ context.Context, nodeID ids.NodeID, requestID uint32) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
-	if n.closed.Get() {
-		return nil
-	}
-
+func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
 	log.Debug("received AppRequestFailed from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received AppRequestFailed to unknown request", "nodeID", nodeID, "requestID", requestID)
-		return nil
+		log.Debug("forwarding AppRequestFailed to SDK router", "nodeID", nodeID, "requestID", requestID)
+		return n.router.AppRequestFailed(ctx, nodeID, requestID)
 	}
 
 	// We must release the slot
@@ -445,8 +420,11 @@ func calculateTimeUntilDeadline(deadline time.Time, stats stats.RequestHandlerSt
 
 // markRequestFulfilled fetches the handler for [requestID] and marks the request with [requestID] as having been fulfilled.
 // This is called by either [AppResponse] or [AppRequestFailed].
-// Assumes that the write lock is held.
+// Assumes that the write lock is not held.
 func (n *network) markRequestFulfilled(requestID uint32) (message.ResponseHandler, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	handler, exists := n.outstandingRequestHandlers[requestID]
 	if !exists {
 		return nil, false
@@ -470,10 +448,6 @@ func (n *network) Gossip(gossip []byte) error {
 // error returned by this function is expected to be treated as fatal by the engine
 // returns error if request could not be parsed as message.Request or when the requestHandler returns an error
 func (n *network) AppGossip(_ context.Context, nodeID ids.NodeID, gossipBytes []byte) error {
-	if n.closed.Get() {
-		return nil
-	}
-
 	var gossipMsg message.GossipMessage
 	if _, err := n.codec.Unmarshal(gossipBytes, &gossipMsg); err != nil {
 		log.Debug("could not parse app gossip", "nodeID", nodeID, "gossipLen", len(gossipBytes), "err", err)
@@ -566,4 +540,16 @@ func (n *network) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {
 	defer n.lock.Unlock()
 
 	n.peers.TrackBandwidth(nodeID, bandwidth)
+}
+
+// invariant: peer/network must use explicitly even request ids.
+// for this reason, [n.requestID] is initialized as zero and incremented by 2.
+// This is for backwards-compatibility while the SDK router exists with the
+// legacy coreth handlers to avoid a (very) narrow edge case where request ids
+// can overlap, resulting in a dropped timeout.
+func (n *network) nextRequestID() uint32 {
+	next := n.requestIDGen
+	n.requestIDGen += 2
+
+	return next
 }

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -12,9 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/coreth/plugin/evm/message"
 
@@ -49,11 +52,13 @@ var (
 
 	_ message.CrossChainRequest        = &ExampleCrossChainRequest{}
 	_ message.CrossChainRequestHandler = &testCrossChainHandler{}
+
+	_ p2p.Handler = &testSDKHandler{}
 )
 
 func TestNetworkDoesNotConnectToItself(t *testing.T) {
 	selfNodeID := ids.GenerateTestNodeID()
-	n := NewNetwork(nil, nil, nil, selfNodeID, 1, 1)
+	n := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), nil, nil, nil, selfNodeID, 1, 1)
 	assert.NoError(t, n.Connected(context.Background(), selfNodeID, defaultPeerVersion))
 	assert.EqualValues(t, 0, n.Size())
 }
@@ -89,7 +94,7 @@ func TestRequestAnyRequestsRoutingAndResponse(t *testing.T) {
 
 	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 16, 16)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 16, 16)
 	net.SetRequestHandler(&HelloGreetingRequestHandler{codec: codecManager})
 	client := NewNetworkClient(net)
 	nodeID := ids.GenerateTestNodeID()
@@ -164,7 +169,7 @@ func TestRequestRequestsRoutingAndResponse(t *testing.T) {
 
 	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 16, 16)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 16, 16)
 	net.SetRequestHandler(&HelloGreetingRequestHandler{codec: codecManager})
 	client := NewNetworkClient(net)
 
@@ -244,7 +249,7 @@ func TestAppRequestOnShutdown(t *testing.T) {
 
 	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	client := NewNetworkClient(net)
 	nodeID := ids.GenerateTestNodeID()
 	require.NoError(t, net.Connected(context.Background(), nodeID, defaultPeerVersion))
@@ -293,7 +298,7 @@ func TestRequestMinVersion(t *testing.T) {
 	}
 
 	// passing nil as codec works because the net.AppRequest is never called
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 16)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 16)
 	client := NewNetworkClient(net)
 	requestMessage := TestMessage{Message: "this is a request"}
 	requestBytes, err := message.RequestToBytes(codecManager, requestMessage)
@@ -356,7 +361,7 @@ func TestOnRequestHonoursDeadline(t *testing.T) {
 		processingDuration: 500 * time.Millisecond,
 	}
 
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetRequestHandler(requestHandler)
 	nodeID := ids.GenerateTestNodeID()
 
@@ -396,7 +401,7 @@ func TestGossip(t *testing.T) {
 	}
 
 	gossipHandler := &testGossipHandler{}
-	clientNetwork = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	clientNetwork = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	clientNetwork.SetGossipHandler(gossipHandler)
 
 	assert.NoError(t, clientNetwork.Connected(context.Background(), nodeID, defaultPeerVersion))
@@ -423,7 +428,7 @@ func TestHandleInvalidMessages(t *testing.T) {
 	requestID := uint32(1)
 	sender := testAppSender{}
 
-	clientNetwork := NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	clientNetwork := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	clientNetwork.SetGossipHandler(message.NoopMempoolGossipHandler{})
 	clientNetwork.SetRequestHandler(&testRequestHandler{})
 
@@ -457,12 +462,11 @@ func TestHandleInvalidMessages(t *testing.T) {
 	assert.NoError(t, clientNetwork.AppRequest(context.Background(), nodeID, requestID, time.Now().Add(time.Second), garbageResponse))
 	assert.NoError(t, clientNetwork.AppRequest(context.Background(), nodeID, requestID, time.Now().Add(time.Second), emptyResponse))
 	assert.NoError(t, clientNetwork.AppRequest(context.Background(), nodeID, requestID, time.Now().Add(time.Second), nilResponse))
-	assert.NoError(t, clientNetwork.AppResponse(context.Background(), nodeID, requestID, gossipMsg))
-	assert.NoError(t, clientNetwork.AppResponse(context.Background(), nodeID, requestID, requestMessage))
-	assert.NoError(t, clientNetwork.AppResponse(context.Background(), nodeID, requestID, garbageResponse))
-	assert.NoError(t, clientNetwork.AppResponse(context.Background(), nodeID, requestID, emptyResponse))
-	assert.NoError(t, clientNetwork.AppResponse(context.Background(), nodeID, requestID, nilResponse))
-	assert.NoError(t, clientNetwork.AppRequestFailed(context.Background(), nodeID, requestID))
+	assert.ErrorIs(t, p2p.ErrUnrequestedResponse, clientNetwork.AppResponse(context.Background(), nodeID, requestID, gossipMsg))
+	assert.ErrorIs(t, p2p.ErrUnrequestedResponse, clientNetwork.AppResponse(context.Background(), nodeID, requestID, requestMessage))
+	assert.ErrorIs(t, p2p.ErrUnrequestedResponse, clientNetwork.AppResponse(context.Background(), nodeID, requestID, garbageResponse))
+	assert.ErrorIs(t, p2p.ErrUnrequestedResponse, clientNetwork.AppResponse(context.Background(), nodeID, requestID, emptyResponse))
+	assert.ErrorIs(t, p2p.ErrUnrequestedResponse, clientNetwork.AppResponse(context.Background(), nodeID, requestID, nilResponse))
 }
 
 func TestNetworkPropagatesRequestHandlerError(t *testing.T) {
@@ -473,7 +477,7 @@ func TestNetworkPropagatesRequestHandlerError(t *testing.T) {
 	requestID := uint32(1)
 	sender := testAppSender{}
 
-	clientNetwork := NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	clientNetwork := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	clientNetwork.SetGossipHandler(message.NoopMempoolGossipHandler{})
 	clientNetwork.SetRequestHandler(&testRequestHandler{err: errors.New("fail")}) // Return an error from the request handler
 
@@ -513,7 +517,7 @@ func TestCrossChainAppRequest(t *testing.T) {
 		},
 	}
 
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetCrossChainRequestHandler(&testCrossChainHandler{codec: crossChainCodecManager})
 	client := NewNetworkClient(net)
 
@@ -568,7 +572,7 @@ func TestCrossChainRequestRequestsRoutingAndResponse(t *testing.T) {
 
 	codecManager := buildCodec(t, TestMessage{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetCrossChainRequestHandler(&testCrossChainHandler{codec: crossChainCodecManager})
 	client := NewNetworkClient(net)
 
@@ -628,7 +632,7 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 	}
 	codecManager := buildCodec(t, TestMessage{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
-	net = NewNetwork(sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	client := NewNetworkClient(net)
 
 	exampleCrossChainRequest := ExampleCrossChainRequest{
@@ -647,6 +651,68 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 	}()
 	wg.Wait()
 	require.True(t, called)
+}
+
+func TestNetworkAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 1, 0)
+	net.Shutdown()
+
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+}
+
+func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 0, 1)
+	net.Shutdown()
+
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+}
+
+func TestSDKRouting(t *testing.T) {
+	require := require.New(t)
+	sender := &testAppSender{
+		sendAppRequestFn: func(s set.Set[ids.NodeID], u uint32, bytes []byte) error {
+			return nil
+		},
+		sendAppResponseFn: func(id ids.NodeID, u uint32, bytes []byte) error {
+			return nil
+		},
+	}
+	protocol := 0
+	handler := &testSDKHandler{}
+	router := p2p.NewRouter(logging.NoLog{}, sender, prometheus.NewRegistry(), "")
+	_, err := router.RegisterAppProtocol(uint64(protocol), handler, nil)
+	require.NoError(err)
+
+	networkCodec := codec.NewManager(0)
+	crossChainCodec := codec.NewManager(0)
+
+	network := NewNetwork(
+		router,
+		nil,
+		networkCodec,
+		crossChainCodec,
+		ids.EmptyNodeID,
+		1,
+		1,
+	)
+
+	nodeID := ids.GenerateTestNodeID()
+	foobar := append([]byte{byte(protocol)}, []byte("foobar")...)
+	err = network.AppRequest(context.Background(), nodeID, 0, time.Time{}, foobar)
+	require.NoError(err)
+	require.True(handler.appRequested)
+
+	err = network.AppResponse(context.Background(), ids.GenerateTestNodeID(), 0, foobar)
+	require.ErrorIs(err, p2p.ErrUnrequestedResponse)
+
+	err = network.AppRequestFailed(context.Background(), nodeID, 0)
+	require.ErrorIs(err, p2p.ErrUnrequestedResponse)
 }
 
 func buildCodec(t *testing.T, types ...interface{}) codec.Manager {
@@ -849,4 +915,23 @@ type testCrossChainHandler struct {
 
 func (t *testCrossChainHandler) HandleCrossChainRequest(ctx context.Context, requestingChainID ids.ID, requestID uint32, exampleRequest message.CrossChainRequest) ([]byte, error) {
 	return t.codec.Marshal(message.Version, ExampleCrossChainResponse{Response: "this is an example response"})
+}
+
+type testSDKHandler struct {
+	appRequested bool
+}
+
+func (t *testSDKHandler) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (t *testSDKHandler) AppRequest(ctx context.Context, nodeID ids.NodeID, deadline time.Time, requestBytes []byte) ([]byte, error) {
+	t.appRequested = true
+	return nil, nil
+}
+
+func (t *testSDKHandler) CrossChainAppRequest(ctx context.Context, chainID ids.ID, deadline time.Time, requestBytes []byte) ([]byte, error) {
+	// TODO implement me
+	panic("implement me")
 }

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -652,6 +652,26 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 	require.True(t, called)
 }
 
+func TestNetworkAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 1, 0)
+	net.Shutdown()
+
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+}
+
+func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 0, 1)
+	net.Shutdown()
+
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+}
+
 func TestSDKRouting(t *testing.T) {
 	require := require.New(t)
 	sender := &testAppSender{

--- a/plugin/evm/camino_syncervm_test.go
+++ b/plugin/evm/camino_syncervm_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSkipStateSyncCamino(t *testing.T) {
@@ -37,50 +37,25 @@ func TestSkipStateSyncCamino(t *testing.T) {
 		syncMode:           block.StateSyncSkipped,
 	}
 	vmSetup := createSyncServerAndClientVMsCamino(t, test)
-	defer vmSetup.Teardown(t)
 
 	testSyncerVM(t, vmSetup, test)
 }
 
 func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetup {
 	var (
-		serverVM, syncerVM *VM
-	)
-	// If there is an error shutdown the VMs if they have been instantiated
-	defer func() {
-		// If the test has not already failed, shut down the VMs since the caller
-		// will not get the chance to shut them down.
-		if !t.Failed() {
-			return
-		}
-
-		// If the test already failed, shut down the VMs if they were instantiated.
-		if serverVM != nil {
-			log.Info("Shutting down server VM")
-			if err := serverVM.Shutdown(context.Background()); err != nil {
-				t.Fatal(err)
-			}
-		}
-		if syncerVM != nil {
-			log.Info("Shutting down syncerVM")
-			if err := syncerVM.Shutdown(context.Background()); err != nil {
-				t.Fatal(err)
-			}
-		}
-	}()
-
-	// configure [serverVM]
-	importAmount := 2000000 * units.Avax // 2M avax
-	_, serverVM, _, serverAtomicMemory, serverAppSender := GenesisVMWithUTXOs(
-		t,
-		true,
-		genesisJSONSunrisePhase0,
-		"",
-		"",
-		map[ids.ShortID]uint64{
+		require      = require.New(t)
+		importAmount = 2000000 * units.Avax // 2M avax
+		alloc        = map[ids.ShortID]uint64{
 			testShortIDAddrs[0]: importAmount,
-		},
+		}
 	)
+	_, serverVM, _, serverAtomicMemory, serverAppSender := GenesisVMWithUTXOs(
+		t, true, genesisJSONSunrisePhase0, "", "", alloc,
+	)
+	t.Cleanup(func() {
+		log.Info("Shutting down server VM")
+		require.NoError(serverVM.Shutdown(context.Background()))
+	})
 
 	var (
 		importTx, exportTx *Tx
@@ -91,12 +66,8 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 		case 0:
 			// spend the UTXOs from shared memory
 			importTx, err = serverVM.newImportTx(serverVM.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := serverVM.issueTx(importTx, true /*=local*/); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(err)
+			require.NoError(serverVM.issueTx(importTx, true /*=local*/))
 		case 1:
 			// export some of the imported UTXOs to test exportTx is properly synced
 			exportTx, err = serverVM.newExportTx(
@@ -107,19 +78,13 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 				initialBaseFee,
 				[]*secp256k1.PrivateKey{testKeys[0]},
 			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := serverVM.issueTx(exportTx, true /*=local*/); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(err)
+			require.NoError(serverVM.issueTx(exportTx, true /*=local*/))
 		default: // Generate simple transfer transactions.
 			pk := testKeys[0].ToECDSA()
 			tx := types.NewTransaction(gen.TxNonce(testEthAddrs[0]), testEthAddrs[1], common.Big1, params.TxGas, initialBaseFee, nil)
 			signedTx, err := types.SignTx(tx, types.NewEIP155Signer(serverVM.chainID), pk)
-			if err != nil {
-				t.Fatal(t)
-			}
+			require.NoError(err)
 			gen.AddTx(signedTx)
 		}
 	})
@@ -129,8 +94,8 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 	// fetching a state summary.
 	serverAtomicTrie := serverVM.atomicTrie.(*atomicTrie)
 	serverAtomicTrie.commitInterval = test.syncableInterval
-	assert.NoError(t, serverAtomicTrie.commit(test.syncableInterval, serverAtomicTrie.LastAcceptedRoot()))
-	assert.NoError(t, serverVM.db.Commit())
+	require.NoError(serverAtomicTrie.commit(test.syncableInterval, serverAtomicTrie.LastAcceptedRoot()))
+	require.NoError(serverVM.db.Commit())
 
 	serverSharedMemories := newSharedMemories(serverAtomicMemory, serverVM.ctx.ChainID, serverVM.ctx.XChainID)
 	serverSharedMemories.assertOpsApplied(t, importTx.mustAtomicOps())
@@ -146,37 +111,28 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 	lastAccepted := serverVM.blockChain.LastAcceptedBlock()
 	patchedBlock := patchBlock(lastAccepted, root, serverVM.chaindb)
 	blockBytes, err := rlp.EncodeToBytes(patchedBlock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	internalBlock, err := serverVM.parseBlock(context.Background(), blockBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 	internalBlock.(*Block).SetStatus(choices.Accepted)
-	assert.NoError(t, serverVM.State.SetLastAcceptedBlock(internalBlock))
+	require.NoError(serverVM.State.SetLastAcceptedBlock(internalBlock))
 
 	// patch syncableInterval for test
 	serverVM.StateSyncServer.(*stateSyncServer).syncableInterval = test.syncableInterval
 
 	// initialise [syncerVM] with blank genesis state
-	stateSyncEnabledJSON := fmt.Sprintf("{\"state-sync-enabled\":true, \"state-sync-min-blocks\": %d}", test.stateSyncMinBlocks)
+	stateSyncEnabledJSON := fmt.Sprintf(`{"state-sync-enabled":true, "state-sync-min-blocks": %d}`, test.stateSyncMinBlocks)
 	syncerEngineChan, syncerVM, syncerDBManager, syncerAtomicMemory, syncerAppSender := GenesisVMWithUTXOs(
-		t,
-		false,
-		"",
-		stateSyncEnabledJSON,
-		"",
-		map[ids.ShortID]uint64{
-			testShortIDAddrs[0]: importAmount,
-		},
+		t, false, "", stateSyncEnabledJSON, "", alloc,
 	)
-	if err := syncerVM.SetState(context.Background(), snow.StateSyncing); err != nil {
-		t.Fatal(err)
-	}
+	shutdownOnceSyncerVM := &shutdownOnceVM{VM: syncerVM}
+	t.Cleanup(func() {
+		require.NoError(shutdownOnceSyncerVM.Shutdown(context.Background()))
+	})
+	require.NoError(syncerVM.SetState(context.Background(), snow.StateSyncing))
 	enabled, err := syncerVM.StateSyncEnabled(context.Background())
-	assert.NoError(t, err)
-	assert.True(t, enabled)
+	require.NoError(err)
+	require.True(enabled)
 
 	// override [syncerVM]'s commit interval so the atomic trie works correctly.
 	syncerVM.atomicTrie.(*atomicTrie).commitInterval = test.syncableInterval
@@ -193,19 +149,20 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 	}
 
 	// connect peer to [syncerVM]
-	assert.NoError(t, syncerVM.Connected(
-		context.Background(),
-		serverVM.ctx.NodeID,
-		statesyncclient.StateSyncVersion,
-	))
+	require.NoError(
+		syncerVM.Connected(
+			context.Background(),
+			serverVM.ctx.NodeID,
+			statesyncclient.StateSyncVersion,
+		),
+	)
 
 	// override [syncerVM]'s SendAppRequest function to trigger AppRequest on [serverVM]
 	syncerAppSender.SendAppRequestF = func(ctx context.Context, nodeSet set.Set[ids.NodeID], requestID uint32, request []byte) error {
 		nodeID, hasItem := nodeSet.Pop()
-		if !hasItem {
-			t.Fatal("expected nodeSet to contain at least 1 nodeID")
-		}
-		go serverVM.AppRequest(ctx, nodeID, requestID, time.Now().Add(1*time.Second), request)
+		require.True(hasItem, "expected nodeSet to contain at least 1 nodeID")
+		err := serverVM.AppRequest(ctx, nodeID, requestID, time.Now().Add(1*time.Second), request)
+		require.NoError(err)
 		return nil
 	}
 
@@ -216,10 +173,11 @@ func createSyncServerAndClientVMsCamino(t *testing.T, test syncTest) *syncVMSetu
 			importTx,
 			exportTx,
 		},
-		fundedAccounts:     accounts,
-		syncerVM:           syncerVM,
-		syncerDBManager:    syncerDBManager,
-		syncerEngineChan:   syncerEngineChan,
-		syncerAtomicMemory: syncerAtomicMemory,
+		fundedAccounts:       accounts,
+		syncerVM:             syncerVM,
+		syncerDBManager:      syncerDBManager,
+		syncerEngineChan:     syncerEngineChan,
+		syncerAtomicMemory:   syncerAtomicMemory,
+		shutdownOnceSyncerVM: shutdownOnceSyncerVM,
 	}
 }

--- a/plugin/evm/gossip_mempool.go
+++ b/plugin/evm/gossip_mempool.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/txpool"
+	"github.com/ava-labs/coreth/core/types"
+)
+
+var (
+	_ gossip.Gossipable        = (*GossipEthTx)(nil)
+	_ gossip.Gossipable        = (*GossipAtomicTx)(nil)
+	_ gossip.Set[*GossipEthTx] = (*GossipEthTxPool)(nil)
+)
+
+type GossipAtomicTx struct {
+	Tx *Tx
+}
+
+func (tx *GossipAtomicTx) GetID() ids.ID {
+	return tx.Tx.ID()
+}
+
+func (tx *GossipAtomicTx) Marshal() ([]byte, error) {
+	return tx.Tx.SignedBytes(), nil
+}
+
+func (tx *GossipAtomicTx) Unmarshal(bytes []byte) error {
+	atomicTx, err := ExtractAtomicTx(bytes, Codec)
+	tx.Tx = atomicTx
+
+	return err
+}
+
+func NewGossipEthTxPool(mempool *txpool.TxPool) (*GossipEthTxPool, error) {
+	bloom, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize bloom filter: %w", err)
+	}
+
+	return &GossipEthTxPool{
+		mempool:    mempool,
+		pendingTxs: make(chan core.NewTxsEvent),
+		bloom:      bloom,
+	}, nil
+}
+
+type GossipEthTxPool struct {
+	mempool    *txpool.TxPool
+	pendingTxs chan core.NewTxsEvent
+
+	bloom *gossip.BloomFilter
+	lock  sync.RWMutex
+}
+
+func (g *GossipEthTxPool) Subscribe(ctx context.Context) {
+	g.mempool.SubscribeNewTxsEvent(g.pendingTxs)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debug("shutting down subscription")
+			return
+		case pendingTxs := <-g.pendingTxs:
+			g.lock.Lock()
+			for _, pendingTx := range pendingTxs.Txs {
+				tx := &GossipEthTx{Tx: pendingTx}
+				g.bloom.Add(tx)
+				reset, err := gossip.ResetBloomFilterIfNeeded(g.bloom, txGossipMaxFalsePositiveRate)
+				if err != nil {
+					log.Error("failed to reset bloom filter", "err", err)
+					continue
+				}
+
+				if reset {
+					log.Debug("resetting bloom filter", "reason", "reached max filled ratio")
+
+					g.mempool.IteratePending(func(tx *types.Transaction) bool {
+						g.bloom.Add(&GossipEthTx{Tx: pendingTx})
+						return true
+					})
+				}
+			}
+			g.lock.Unlock()
+		}
+	}
+}
+
+// Add enqueues the transaction to the mempool. Subscribe should be called
+// to receive an event if tx is actually added to the mempool or not.
+func (g *GossipEthTxPool) Add(tx *GossipEthTx) error {
+	return g.mempool.AddRemotes([]*types.Transaction{tx.Tx})[0]
+}
+
+func (g *GossipEthTxPool) Iterate(f func(tx *GossipEthTx) bool) {
+	g.mempool.IteratePending(func(tx *types.Transaction) bool {
+		return f(&GossipEthTx{Tx: tx})
+	})
+}
+
+func (g *GossipEthTxPool) GetFilter() ([]byte, []byte, error) {
+	g.lock.RLock()
+	defer g.lock.RUnlock()
+
+	bloom, err := g.bloom.Bloom.MarshalBinary()
+	salt := g.bloom.Salt
+
+	return bloom, salt[:], err
+}
+
+type GossipEthTx struct {
+	Tx *types.Transaction
+}
+
+func (tx *GossipEthTx) GetID() ids.ID {
+	return ids.ID(tx.Tx.Hash())
+}
+
+func (tx *GossipEthTx) Marshal() ([]byte, error) {
+	return tx.Tx.MarshalBinary()
+}
+
+func (tx *GossipEthTx) Unmarshal(bytes []byte) error {
+	tx.Tx = &types.Transaction{}
+	return tx.Tx.UnmarshalBinary(bytes)
+}

--- a/plugin/evm/gossip_mempool_test.go
+++ b/plugin/evm/gossip_mempool_test.go
@@ -1,0 +1,119 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+func TestGossipAtomicTxMarshal(t *testing.T) {
+	require := require.New(t)
+
+	expected := &GossipAtomicTx{
+		Tx: &Tx{
+			UnsignedAtomicTx: &UnsignedImportTx{},
+			Creds:            []verify.Verifiable{},
+		},
+	}
+
+	key0 := testKeys[0]
+	require.NoError(expected.Tx.Sign(Codec, [][]*secp256k1.PrivateKey{{key0}}))
+
+	bytes, err := expected.Marshal()
+	require.NoError(err)
+
+	actual := &GossipAtomicTx{}
+	require.NoError(actual.Unmarshal(bytes))
+
+	require.NoError(err)
+	require.Equal(expected.GetID(), actual.GetID())
+}
+
+func TestAtomicMempoolIterate(t *testing.T) {
+	txs := []*GossipAtomicTx{
+		{
+			Tx: &Tx{
+				UnsignedAtomicTx: &TestUnsignedTx{
+					IDV: ids.GenerateTestID(),
+				},
+			},
+		},
+		{
+			Tx: &Tx{
+				UnsignedAtomicTx: &TestUnsignedTx{
+					IDV: ids.GenerateTestID(),
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		add            []*GossipAtomicTx
+		f              func(tx *GossipAtomicTx) bool
+		possibleValues []*GossipAtomicTx
+		expectedLen    int
+	}{
+		{
+			name: "func matches nothing",
+			add:  txs,
+			f: func(*GossipAtomicTx) bool {
+				return false
+			},
+			possibleValues: nil,
+		},
+		{
+			name: "func matches all",
+			add:  txs,
+			f: func(*GossipAtomicTx) bool {
+				return true
+			},
+			possibleValues: txs,
+			expectedLen:    2,
+		},
+		{
+			name: "func matches subset",
+			add:  txs,
+			f: func(tx *GossipAtomicTx) bool {
+				return tx.Tx == txs[0].Tx
+			},
+			possibleValues: txs,
+			expectedLen:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			m, err := NewMempool(ids.Empty, 10)
+			require.NoError(err)
+
+			for _, add := range tt.add {
+				require.NoError(m.Add(add))
+			}
+
+			matches := make([]*GossipAtomicTx, 0)
+			f := func(tx *GossipAtomicTx) bool {
+				match := tt.f(tx)
+
+				if match {
+					matches = append(matches, tx)
+				}
+
+				return match
+			}
+
+			m.Iterate(f)
+
+			require.Len(matches, tt.expectedLen)
+			require.Subset(tt.possibleValues, matches)
+		})
+	}
+}

--- a/plugin/evm/mempool_test.go
+++ b/plugin/evm/mempool_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMempoolAddTx(t *testing.T) {
+	require := require.New(t)
+	m, err := NewMempool(ids.Empty, 5_000)
+	require.NoError(err)
+
+	txs := make([]*GossipAtomicTx, 0)
+	for i := 0; i < 3_000; i++ {
+		tx := &GossipAtomicTx{
+			Tx: &Tx{
+				UnsignedAtomicTx: &TestUnsignedTx{
+					IDV: ids.GenerateTestID(),
+				},
+			},
+		}
+
+		txs = append(txs, tx)
+		require.NoError(m.Add(tx))
+	}
+
+	for _, tx := range txs {
+		require.True(m.bloom.Has(tx))
+	}
+}

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -1,0 +1,254 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/proto/pb/sdk"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/params"
+)
+
+func TestEthTxGossip(t *testing.T) {
+	require := require.New(t)
+
+	// set up prefunded address
+	importAmount := uint64(1_000_000_000)
+	issuer, vm, _, _, sender := GenesisVMWithUTXOs(t, true, genesisJSONLatest, "", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+	})
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+	}()
+
+	txPoolNewHeads := make(chan core.NewTxPoolHeadEvent)
+	vm.txPool.SubscribeNewHeadEvent(txPoolNewHeads)
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
+	require.NoError(err)
+	require.NoError(vm.issueTx(importTx, true))
+	<-issuer
+
+	blk, err := vm.BuildBlock(context.Background())
+	require.NoError(err)
+
+	require.NoError(blk.Verify(context.Background()))
+	require.NoError(vm.SetPreference(context.Background(), blk.ID()))
+	require.NoError(blk.Accept(context.Background()))
+	<-txPoolNewHeads
+
+	// sender for the peer requesting gossip from [vm]
+	ctrl := gomock.NewController(t)
+	peerSender := common.NewMockSender(ctrl)
+	router := p2p.NewRouter(logging.NoLog{}, peerSender, prometheus.NewRegistry(), "")
+
+	// we're only making client requests, so we don't need a server handler
+	client, err := router.RegisterAppProtocol(ethTxGossipProtocol, nil, nil)
+	require.NoError(err)
+
+	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
+	require.NoError(err)
+	emptyBloomFilterBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	require.NoError(err)
+	request := &sdk.PullGossipRequest{
+		Filter: emptyBloomFilterBytes,
+		Salt:   utils.RandomBytes(32),
+	}
+
+	requestBytes, err := proto.Marshal(request)
+	require.NoError(err)
+
+	wg := &sync.WaitGroup{}
+
+	requestingNodeID := ids.GenerateTestNodeID()
+	peerSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) {
+		go func() {
+			require.NoError(vm.AppRequest(ctx, requestingNodeID, requestID, time.Time{}, appRequestBytes))
+		}()
+	}).AnyTimes()
+
+	sender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, appResponseBytes []byte) error {
+		go func() {
+			require.NoError(router.AppResponse(ctx, nodeID, requestID, appResponseBytes))
+		}()
+		return nil
+	}
+
+	// we only accept gossip requests from validators
+	mockValidatorSet, ok := vm.ctx.ValidatorState.(*validators.TestState)
+	require.True(ok)
+	mockValidatorSet.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return 0, nil
+	}
+	mockValidatorSet.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+		return map[ids.NodeID]*validators.GetValidatorOutput{requestingNodeID: nil}, nil
+	}
+
+	// Ask the VM for any new transactions. We should get nothing at first.
+	wg.Add(1)
+	onResponse := func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Empty(response.Gossip)
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+
+	// Issue a tx to the VM
+	address := testEthAddrs[0]
+	key := testKeys[0].ToECDSA()
+	tx := types.NewTransaction(0, address, big.NewInt(10), 100_000, big.NewInt(params.LaunchMinGasPrice), nil)
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm.chainID), key)
+	require.NoError(err)
+
+	errs := vm.txPool.AddLocals([]*types.Transaction{signedTx})
+	require.Len(errs, 1)
+	require.Nil(errs[0])
+
+	// wait so we aren't throttled by the vm
+	time.Sleep(5 * time.Second)
+
+	// Ask the VM for new transactions. We should get the newly issued tx.
+	wg.Add(1)
+	onResponse = func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Len(response.Gossip, 1)
+
+		gotTx := &GossipEthTx{}
+		require.NoError(gotTx.Unmarshal(response.Gossip[0]))
+		require.Equal(signedTx.Hash(), gotTx.Tx.Hash())
+
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+}
+
+func TestAtomicTxGossip(t *testing.T) {
+	require := require.New(t)
+
+	// set up prefunded address
+	importAmount := uint64(1_000_000_000)
+	issuer, vm, _, _, sender := GenesisVMWithUTXOs(t, true, genesisJSONApricotPhase0, "", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+	})
+
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+	}()
+
+	// sender for the peer requesting gossip from [vm]
+	ctrl := gomock.NewController(t)
+	peerSender := common.NewMockSender(ctrl)
+	router := p2p.NewRouter(logging.NoLog{}, peerSender, prometheus.NewRegistry(), "")
+
+	// we're only making client requests, so we don't need a server handler
+	client, err := router.RegisterAppProtocol(atomicTxGossipProtocol, nil, nil)
+	require.NoError(err)
+
+	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
+	require.NoError(err)
+	bloomBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	require.NoError(err)
+	request := &sdk.PullGossipRequest{
+		Filter: bloomBytes,
+		Salt:   emptyBloomFilter.Salt[:],
+	}
+	requestBytes, err := proto.Marshal(request)
+	require.NoError(err)
+
+	requestingNodeID := ids.GenerateTestNodeID()
+	wg := &sync.WaitGroup{}
+	peerSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) {
+		go func() {
+			require.NoError(vm.AppRequest(ctx, requestingNodeID, requestID, time.Time{}, appRequestBytes))
+		}()
+	}).AnyTimes()
+
+	sender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, appResponseBytes []byte) error {
+		go func() {
+			require.NoError(router.AppResponse(ctx, nodeID, requestID, appResponseBytes))
+		}()
+		return nil
+	}
+
+	// we only accept gossip requests from validators
+	mockValidatorSet, ok := vm.ctx.ValidatorState.(*validators.TestState)
+	require.True(ok)
+	mockValidatorSet.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return 0, nil
+	}
+	mockValidatorSet.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+		return map[ids.NodeID]*validators.GetValidatorOutput{requestingNodeID: nil}, nil
+	}
+
+	// Ask the VM for any new transactions. We should get nothing at first.
+	wg.Add(1)
+	onResponse := func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Empty(response.Gossip)
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+
+	// issue a new tx to the vm
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
+	require.NoError(err)
+
+	require.NoError(vm.issueTx(importTx, true /*=local*/))
+	<-issuer
+
+	// wait so we aren't throttled by the vm
+	time.Sleep(5 * time.Second)
+
+	// Ask the VM for new transactions. We should get the newly issued tx.
+	wg.Add(1)
+	onResponse = func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Len(response.Gossip, 1)
+
+		gotTx := &GossipAtomicTx{}
+		require.NoError(gotTx.Unmarshal(response.Gossip[0]))
+		require.Equal(importTx.InputUTXOs(), gotTx.Tx.InputUTXOs())
+
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+}

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -44,8 +44,8 @@ func TestEthTxGossip(t *testing.T) {
 		require.NoError(vm.Shutdown(context.Background()))
 	}()
 
-	importAccepted := make(chan core.NewTxPoolHeadEvent)
-	vm.txPool.SubscribeNewHeadEvent(importAccepted)
+	txPoolNewHeads := make(chan core.NewTxPoolHeadEvent)
+	vm.txPool.SubscribeNewHeadEvent(txPoolNewHeads)
 
 	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(err)
@@ -58,7 +58,7 @@ func TestEthTxGossip(t *testing.T) {
 	require.NoError(blk.Verify(context.Background()))
 	require.NoError(vm.SetPreference(context.Background(), blk.ID()))
 	require.NoError(blk.Accept(context.Background()))
-	<-importAccepted
+	<-txPoolNewHeads
 
 	// sender for the peer requesting gossip from [vm]
 	ctrl := gomock.NewController(t)

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -1,0 +1,254 @@
+// Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/proto/pb/sdk"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/params"
+)
+
+func TestEthTxGossip(t *testing.T) {
+	require := require.New(t)
+
+	// set up prefunded address
+	importAmount := uint64(1_000_000_000)
+	issuer, vm, _, _, sender := GenesisVMWithUTXOs(t, true, genesisJSONLatest, "", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+	})
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+	}()
+
+	importAccepted := make(chan core.NewTxPoolHeadEvent)
+	vm.txPool.SubscribeNewHeadEvent(importAccepted)
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
+	require.NoError(err)
+	require.NoError(vm.issueTx(importTx, true))
+	<-issuer
+
+	blk, err := vm.BuildBlock(context.Background())
+	require.NoError(err)
+
+	require.NoError(blk.Verify(context.Background()))
+	require.NoError(vm.SetPreference(context.Background(), blk.ID()))
+	require.NoError(blk.Accept(context.Background()))
+	<-importAccepted
+
+	// sender for the peer requesting gossip from [vm]
+	ctrl := gomock.NewController(t)
+	peerSender := common.NewMockSender(ctrl)
+	router := p2p.NewRouter(logging.NoLog{}, peerSender, prometheus.NewRegistry(), "")
+
+	// we're only making client requests, so we don't need a server handler
+	client, err := router.RegisterAppProtocol(ethTxGossipProtocol, nil, nil)
+	require.NoError(err)
+
+	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
+	require.NoError(err)
+	emptyBloomFilterBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	require.NoError(err)
+	request := &sdk.PullGossipRequest{
+		Filter: emptyBloomFilterBytes,
+		Salt:   utils.RandomBytes(32),
+	}
+
+	requestBytes, err := proto.Marshal(request)
+	require.NoError(err)
+
+	wg := &sync.WaitGroup{}
+
+	requestingNodeID := ids.GenerateTestNodeID()
+	peerSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) {
+		go func() {
+			require.NoError(vm.AppRequest(ctx, requestingNodeID, requestID, time.Time{}, appRequestBytes))
+		}()
+	}).AnyTimes()
+
+	sender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, appResponseBytes []byte) error {
+		go func() {
+			require.NoError(router.AppResponse(ctx, nodeID, requestID, appResponseBytes))
+		}()
+		return nil
+	}
+
+	// we only accept gossip requests from validators
+	mockValidatorSet, ok := vm.ctx.ValidatorState.(*validators.TestState)
+	require.True(ok)
+	mockValidatorSet.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return 0, nil
+	}
+	mockValidatorSet.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+		return map[ids.NodeID]*validators.GetValidatorOutput{requestingNodeID: nil}, nil
+	}
+
+	// Ask the VM for any new transactions. We should get nothing at first.
+	wg.Add(1)
+	onResponse := func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Empty(response.Gossip)
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+
+	// Issue a tx to the VM
+	address := testEthAddrs[0]
+	key := testKeys[0].ToECDSA()
+	tx := types.NewTransaction(0, address, big.NewInt(10), 100_000, big.NewInt(params.LaunchMinGasPrice), nil)
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm.chainID), key)
+	require.NoError(err)
+
+	errs := vm.txPool.AddLocals([]*types.Transaction{signedTx})
+	require.Len(errs, 1)
+	require.Nil(errs[0])
+
+	// wait so we aren't throttled by the vm
+	time.Sleep(5 * time.Second)
+
+	// Ask the VM for new transactions. We should get the newly issued tx.
+	wg.Add(1)
+	onResponse = func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Len(response.Gossip, 1)
+
+		gotTx := &GossipEthTx{}
+		require.NoError(gotTx.Unmarshal(response.Gossip[0]))
+		require.Equal(signedTx.Hash(), gotTx.Tx.Hash())
+
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+}
+
+func TestAtomicTxGossip(t *testing.T) {
+	require := require.New(t)
+
+	// set up prefunded address
+	importAmount := uint64(1_000_000_000)
+	issuer, vm, _, _, sender := GenesisVMWithUTXOs(t, true, genesisJSONApricotPhase0, "", "", map[ids.ShortID]uint64{
+		testShortIDAddrs[0]: importAmount,
+	})
+
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+	}()
+
+	// sender for the peer requesting gossip from [vm]
+	ctrl := gomock.NewController(t)
+	peerSender := common.NewMockSender(ctrl)
+	router := p2p.NewRouter(logging.NoLog{}, peerSender, prometheus.NewRegistry(), "")
+
+	// we're only making client requests, so we don't need a server handler
+	client, err := router.RegisterAppProtocol(atomicTxGossipProtocol, nil, nil)
+	require.NoError(err)
+
+	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
+	require.NoError(err)
+	bloomBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	require.NoError(err)
+	request := &sdk.PullGossipRequest{
+		Filter: bloomBytes,
+		Salt:   emptyBloomFilter.Salt[:],
+	}
+	requestBytes, err := proto.Marshal(request)
+	require.NoError(err)
+
+	requestingNodeID := ids.GenerateTestNodeID()
+	wg := &sync.WaitGroup{}
+	peerSender.EXPECT().SendAppRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, nodeIDs set.Set[ids.NodeID], requestID uint32, appRequestBytes []byte) {
+		go func() {
+			require.NoError(vm.AppRequest(ctx, requestingNodeID, requestID, time.Time{}, appRequestBytes))
+		}()
+	}).AnyTimes()
+
+	sender.SendAppResponseF = func(ctx context.Context, nodeID ids.NodeID, requestID uint32, appResponseBytes []byte) error {
+		go func() {
+			require.NoError(router.AppResponse(ctx, nodeID, requestID, appResponseBytes))
+		}()
+		return nil
+	}
+
+	// we only accept gossip requests from validators
+	mockValidatorSet, ok := vm.ctx.ValidatorState.(*validators.TestState)
+	require.True(ok)
+	mockValidatorSet.GetCurrentHeightF = func(context.Context) (uint64, error) {
+		return 0, nil
+	}
+	mockValidatorSet.GetValidatorSetF = func(context.Context, uint64, ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+		return map[ids.NodeID]*validators.GetValidatorOutput{requestingNodeID: nil}, nil
+	}
+
+	// Ask the VM for any new transactions. We should get nothing at first.
+	wg.Add(1)
+	onResponse := func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Empty(response.Gossip)
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+
+	// issue a new tx to the vm
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
+	require.NoError(err)
+
+	require.NoError(vm.issueTx(importTx, true /*=local*/))
+	<-issuer
+
+	// wait so we aren't throttled by the vm
+	time.Sleep(5 * time.Second)
+
+	// Ask the VM for new transactions. We should get the newly issued tx.
+	wg.Add(1)
+	onResponse = func(_ context.Context, nodeID ids.NodeID, responseBytes []byte, err error) {
+		require.NoError(err)
+
+		response := &sdk.PullGossipResponse{}
+		require.NoError(proto.Unmarshal(responseBytes, response))
+		require.Len(response.Gossip, 1)
+
+		gotTx := &GossipAtomicTx{}
+		require.NoError(gotTx.Unmarshal(response.Gossip[0]))
+		require.Equal(importTx.InputUTXOs(), gotTx.Tx.InputUTXOs())
+
+		wg.Done()
+	}
+	require.NoError(client.AppRequest(context.Background(), set.Set[ids.NodeID]{vm.ctx.NodeID: struct{}{}}, requestBytes, onResponse))
+	wg.Wait()
+}

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -150,7 +150,9 @@ func executeTxTest(t *testing.T, test atomicTxTest) {
 		// If this test simulates processing txs during bootstrapping (where some verification is skipped),
 		// initialize the block building goroutines normally initialized in SetState(snow.NormalOps).
 		// This ensures that the VM can build a block correctly during the test.
-		vm.initBlockBuilding()
+		if err := vm.initBlockBuilding(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if err := vm.issueTx(tx, true /*=local*/); err != nil {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	avalanchegoMetrics "github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/network/p2p"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	corethConstants "github.com/ava-labs/coreth/constants"
@@ -276,6 +277,8 @@ type VM struct {
 	client       peer.NetworkClient
 	networkCodec codec.Manager
 
+	router *p2p.Router
+
 	// Metrics
 	multiGatherer avalanchegoMetrics.MultiGatherer
 
@@ -506,8 +509,9 @@ func (vm *VM) Initialize(
 	}
 
 	// initialize peer network
+	vm.router = p2p.NewRouter(vm.ctx.Log, appSender)
 	vm.networkCodec = message.Codec
-	vm.Network = peer.NewNetwork(appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
+	vm.Network = peer.NewNetwork(vm.router, appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
 	vm.client = peer.NewNetworkClient(vm.Network)
 
 	if err := vm.initializeChain(lastAcceptedHash); err != nil {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -281,6 +281,7 @@ type VM struct {
 
 	// Metrics
 	multiGatherer avalanchegoMetrics.MultiGatherer
+	sdkMetrics    *prometheus.Registry
 
 	bootstrapped bool
 	IsPlugin     bool
@@ -509,7 +510,7 @@ func (vm *VM) Initialize(
 	}
 
 	// initialize peer network
-	vm.router = p2p.NewRouter(vm.ctx.Log, appSender)
+	vm.router = p2p.NewRouter(vm.ctx.Log, appSender, vm.sdkMetrics, "p2p")
 	vm.networkCodec = message.Codec
 	vm.Network = peer.NewNetwork(vm.router, appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
 	vm.client = peer.NewNetworkClient(vm.Network)
@@ -561,11 +562,15 @@ func (vm *VM) Initialize(
 }
 
 func (vm *VM) initializeMetrics() error {
+	vm.sdkMetrics = prometheus.NewRegistry()
 	vm.multiGatherer = avalanchegoMetrics.NewMultiGatherer()
 	// If metrics are enabled, register the default metrics regitry
 	if metrics.Enabled {
 		gatherer := corethPrometheus.Gatherer(metrics.DefaultRegistry)
 		if err := vm.multiGatherer.Register(ethMetricsPrefix, gatherer); err != nil {
+			return err
+		}
+		if err := vm.multiGatherer.Register("sdk", vm.sdkMetrics); err != nil {
 			return err
 		}
 		// Register [multiGatherer] after registerers have been registered to it

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	avalanchegoMetrics "github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	corethConstants "github.com/ava-labs/coreth/constants"
@@ -137,6 +139,40 @@ const (
 	bytesToIDCacheSize  = 5 * units.MiB
 
 	targetAtomicTxsSize = 40 * units.KiB
+
+	// p2p app protocols
+	ethTxGossipProtocol    = 0x0
+	atomicTxGossipProtocol = 0x1
+
+	// gossip constants
+	txGossipBloomMaxItems          = 8 * 1024
+	txGossipBloomFalsePositiveRate = 0.01
+	txGossipMaxFalsePositiveRate   = 0.05
+	txGossipTargetResponseSize     = 20 * units.KiB
+	maxValidatorSetStaleness       = time.Minute
+	throttlingPeriod               = 10 * time.Second
+	throttlingLimit                = 2
+	gossipFrequency                = 10 * time.Second
+)
+
+var (
+	ethTxGossipConfig = gossip.Config{
+		Namespace: "eth_tx_gossip",
+		PollSize:  10,
+	}
+	ethTxGossipHandlerConfig = gossip.HandlerConfig{
+		Namespace:          "eth_tx_gossip",
+		TargetResponseSize: txGossipTargetResponseSize,
+	}
+
+	atomicTxGossipConfig = gossip.Config{
+		Namespace: "atomic_tx_gossip",
+		PollSize:  10,
+	}
+	atomicTxGossipHandlerConfig = gossip.HandlerConfig{
+		Namespace:          "atomic_tx_gossip",
+		TargetResponseSize: txGossipTargetResponseSize,
+	}
 )
 
 // Define the API endpoints for the VM
@@ -220,6 +256,8 @@ func init() {
 // VM implements the snowman.ChainVM interface
 type VM struct {
 	ctx *snow.Context
+	// [cancel] may be nil until [snow.NormalOp] starts
+	cancel context.CancelFunc
 	// *chain.State helps to implement the VM interface by wrapping blocks
 	// with an efficient caching layer.
 	*chain.State
@@ -286,8 +324,12 @@ type VM struct {
 	client       peer.NetworkClient
 	networkCodec codec.Manager
 
+	validators *p2p.Validators
+	router     *p2p.Router
+
 	// Metrics
 	multiGatherer avalanchegoMetrics.MultiGatherer
+	sdkMetrics    *prometheus.Registry
 
 	bootstrapped bool
 	IsPlugin     bool
@@ -521,15 +563,20 @@ func (vm *VM) Initialize(
 	vm.codec = Codec
 
 	// TODO: read size from settings
-	vm.mempool = NewMempool(chainCtx.AVAXAssetID, defaultMempoolSize)
+	vm.mempool, err = NewMempool(chainCtx.AVAXAssetID, defaultMempoolSize)
+	if err != nil {
+		return fmt.Errorf("failed to initialize mempool: %w", err)
+	}
 
 	if err := vm.initializeMetrics(); err != nil {
 		return err
 	}
 
 	// initialize peer network
+	vm.validators = p2p.NewValidators(vm.ctx.Log, vm.ctx.SubnetID, vm.ctx.ValidatorState, maxValidatorSetStaleness)
+	vm.router = p2p.NewRouter(vm.ctx.Log, appSender, vm.sdkMetrics, "p2p")
 	vm.networkCodec = message.Codec
-	vm.Network = peer.NewNetwork(appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
+	vm.Network = peer.NewNetwork(vm.router, appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
 	vm.client = peer.NewNetworkClient(vm.Network)
 
 	if err := vm.initializeChain(lastAcceptedHash); err != nil {
@@ -579,11 +626,15 @@ func (vm *VM) Initialize(
 }
 
 func (vm *VM) initializeMetrics() error {
+	vm.sdkMetrics = prometheus.NewRegistry()
 	vm.multiGatherer = avalanchegoMetrics.NewMultiGatherer()
 	// If metrics are enabled, register the default metrics regitry
 	if metrics.Enabled {
 		gatherer := corethPrometheus.Gatherer(metrics.DefaultRegistry)
 		if err := vm.multiGatherer.Register(ethMetricsPrefix, gatherer); err != nil {
+			return err
+		}
+		if err := vm.multiGatherer.Register("sdk", vm.sdkMetrics); err != nil {
 			return err
 		}
 		// Register [multiGatherer] after registerers have been registered to it
@@ -749,6 +800,7 @@ func (vm *VM) preBatchOnFinalizeAndAssemble(header *types.Header, state *state.S
 		rules := vm.chainConfig.CaminoRules(header.Number, header.Time)
 		if err := vm.verifyTx(tx, header.ParentHash, header.BaseFee, state, &rules); err != nil {
 			// Discard the transaction from the mempool on failed verification.
+			log.Debug("discarding tx from mempool on failed verification", "txID", tx.ID(), "err", err)
 			vm.mempool.DiscardCurrentTx(tx.ID())
 			state.RevertToSnapshot(snapshot)
 			continue
@@ -758,6 +810,7 @@ func (vm *VM) preBatchOnFinalizeAndAssemble(header *types.Header, state *state.S
 		if err != nil {
 			// Discard the transaction from the mempool and error if the transaction
 			// cannot be marshalled. This should never happen.
+			log.Debug("discarding tx due to unmarshal err", "txID", tx.ID(), "err", err)
 			vm.mempool.DiscardCurrentTx(tx.ID())
 			return nil, nil, nil, fmt.Errorf("failed to marshal atomic transaction %s due to %w", tx.ID(), err)
 		}
@@ -829,6 +882,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(header *types.Header, state *state.
 			// valid, but we discard it early here based on the assumption that the proposed
 			// block will most likely be accepted.
 			// Discard the transaction from the mempool on failed verification.
+			log.Debug("discarding tx due to overlapping input utxos", "txID", tx.ID())
 			vm.mempool.DiscardCurrentTx(tx.ID())
 			continue
 		}
@@ -839,6 +893,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(header *types.Header, state *state.
 			// if it fails verification here.
 			// Note: prior to this point, we have not modified [state] so there is no need to
 			// revert to a snapshot if we discard the transaction prior to this point.
+			log.Debug("discarding tx from mempool due to failed verification", "txID", tx.ID(), "err", err)
 			vm.mempool.DiscardCurrentTx(tx.ID())
 			state.RevertToSnapshot(snapshot)
 			continue
@@ -859,6 +914,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(header *types.Header, state *state.
 		if err != nil {
 			// If we fail to marshal the batch of atomic transactions for any reason,
 			// discard the entire set of current transactions.
+			log.Debug("discarding txs due to error marshaling atomic transactions", "err", err)
 			vm.mempool.DiscardCurrentTxs()
 			return nil, nil, nil, fmt.Errorf("failed to marshal batch of atomic transactions due to %w", err)
 		}
@@ -959,7 +1015,9 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 		return vm.fx.Bootstrapping()
 	case snow.NormalOp:
 		// Initialize goroutines related to block building once we enter normal operation as there is no need to handle mempool gossip before this point.
-		vm.initBlockBuilding()
+		if err := vm.initBlockBuilding(); err != nil {
+			return fmt.Errorf("failed to initialize block building: %w", err)
+		}
 		if num := vm.DeferedChecks.Count(); num > 0 {
 			return fmt.Errorf("%d blocks has been verified", num)
 		}
@@ -971,13 +1029,115 @@ func (vm *VM) SetState(_ context.Context, state snow.State) error {
 }
 
 // initBlockBuilding starts goroutines to manage block building
-func (vm *VM) initBlockBuilding() {
+func (vm *VM) initBlockBuilding() error {
+	ctx, cancel := context.WithCancel(context.TODO())
+	vm.cancel = cancel
+
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
 	gossipStats := NewGossipStats()
 	vm.gossiper = vm.createGossiper(gossipStats)
 	vm.builder = vm.NewBlockBuilder(vm.toEngine)
 	vm.builder.awaitSubmittedTxs()
 	vm.Network.SetGossipHandler(NewGossipHandler(vm, gossipStats))
+
+	ethTxPool, err := NewGossipEthTxPool(vm.txPool)
+	if err != nil {
+		return err
+	}
+	vm.shutdownWg.Add(1)
+	go func() {
+		ethTxPool.Subscribe(ctx)
+		vm.shutdownWg.Done()
+	}()
+
+	var (
+		ethTxGossipHandler    p2p.Handler
+		atomicTxGossipHandler p2p.Handler
+	)
+
+	ethTxGossipHandler, err = gossip.NewHandler[*GossipEthTx](ethTxPool, ethTxGossipHandlerConfig, vm.sdkMetrics)
+	if err != nil {
+		return err
+	}
+	ethTxGossipHandler = &p2p.ValidatorHandler{
+		ValidatorSet: vm.validators,
+		Handler: &p2p.ThrottlerHandler{
+			Throttler: p2p.NewSlidingWindowThrottler(throttlingPeriod, throttlingLimit),
+			Handler:   ethTxGossipHandler,
+		},
+	}
+	ethTxGossipClient, err := vm.router.RegisterAppProtocol(ethTxGossipProtocol, ethTxGossipHandler, vm.validators)
+	if err != nil {
+		return err
+	}
+
+	atomicTxGossipHandler, err = gossip.NewHandler[*GossipAtomicTx](vm.mempool, atomicTxGossipHandlerConfig, vm.sdkMetrics)
+	if err != nil {
+		return err
+	}
+
+	atomicTxGossipHandler = &p2p.ValidatorHandler{
+		ValidatorSet: vm.validators,
+		Handler: &p2p.ThrottlerHandler{
+			Throttler: p2p.NewSlidingWindowThrottler(throttlingPeriod, throttlingLimit),
+			Handler:   atomicTxGossipHandler,
+		},
+	}
+
+	atomicTxGossipClient, err := vm.router.RegisterAppProtocol(atomicTxGossipProtocol, atomicTxGossipHandler, vm.validators)
+	if err != nil {
+		return err
+	}
+
+	var (
+		ethTxGossiper    gossip.Gossiper
+		atomicTxGossiper gossip.Gossiper
+	)
+	ethTxGossiper, err = gossip.NewPullGossiper[GossipEthTx, *GossipEthTx](
+		ethTxGossipConfig,
+		vm.ctx.Log,
+		ethTxPool,
+		ethTxGossipClient,
+		vm.sdkMetrics,
+	)
+	if err != nil {
+		return err
+	}
+	ethTxGossiper = gossip.ValidatorGossiper{
+		Gossiper:   ethTxGossiper,
+		NodeID:     vm.ctx.NodeID,
+		Validators: vm.validators,
+	}
+
+	vm.shutdownWg.Add(1)
+	go func() {
+		gossip.Every(ctx, vm.ctx.Log, ethTxGossiper, gossipFrequency)
+		vm.shutdownWg.Done()
+	}()
+
+	atomicTxGossiper, err = gossip.NewPullGossiper[GossipAtomicTx, *GossipAtomicTx](
+		atomicTxGossipConfig,
+		vm.ctx.Log,
+		vm.mempool,
+		atomicTxGossipClient,
+		vm.sdkMetrics,
+	)
+	if err != nil {
+		return err
+	}
+	atomicTxGossiper = gossip.ValidatorGossiper{
+		Gossiper:   atomicTxGossiper,
+		NodeID:     vm.ctx.NodeID,
+		Validators: vm.validators,
+	}
+
+	vm.shutdownWg.Add(1)
+	go func() {
+		gossip.Every(ctx, vm.ctx.Log, atomicTxGossiper, gossipFrequency)
+		vm.shutdownWg.Done()
+	}()
+
+	return nil
 }
 
 // setAppRequestHandlers sets the request handlers for the VM to serve state sync
@@ -1015,6 +1175,9 @@ func (vm *VM) Shutdown(context.Context) error {
 	if vm.ctx == nil {
 		return nil
 	}
+	if vm.cancel != nil {
+		vm.cancel()
+	}
 	vm.Network.Shutdown()
 	if err := vm.StateSyncClient.Shutdown(); err != nil {
 		log.Error("error stopping state syncer", "err", err)
@@ -1037,6 +1200,7 @@ func (vm *VM) buildBlock(ctx context.Context) (snowman.Block, error) {
 	// Note: the status of block is set by ChainState
 	blk, err := vm.newBlock(block)
 	if err != nil {
+		log.Debug("discarding txs due to error making new block", "err", err)
 		vm.mempool.DiscardCurrentTxs()
 		return nil, err
 	}
@@ -1362,7 +1526,7 @@ func (vm *VM) issueTx(tx *Tx, local bool) error {
 		}
 		return err
 	}
-	// NOTE: Gossiping of the issued [Tx] is handled in [AddTx]
+
 	return nil
 }
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -29,6 +29,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -174,6 +175,53 @@ func TestClientBatchRequest(t *testing.T) {
 	if !reflect.DeepEqual(batch, wantResult) {
 		t.Errorf("batch results mismatch:\ngot %swant %s", spew.Sdump(batch), spew.Sdump(wantResult))
 	}
+}
+
+func TestClientBatchRequest_len(t *testing.T) {
+	b, err := json.Marshal([]jsonrpcMessage{
+		{Version: "2.0", ID: json.RawMessage("1"), Method: "foo", Result: json.RawMessage(`"0x1"`)},
+		{Version: "2.0", ID: json.RawMessage("2"), Method: "bar", Result: json.RawMessage(`"0x2"`)},
+	})
+	if err != nil {
+		t.Fatal("failed to encode jsonrpc message:", err)
+	}
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(b)
+		if err != nil {
+			t.Error("failed to write response:", err)
+		}
+	}))
+	t.Cleanup(s.Close)
+
+	client, err := Dial(s.URL)
+	if err != nil {
+		t.Fatal("failed to dial test server:", err)
+	}
+	defer client.Close()
+
+	t.Run("too-few", func(t *testing.T) {
+		batch := []BatchElem{
+			{Method: "foo"},
+			{Method: "bar"},
+			{Method: "baz"},
+		}
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+		if err := client.BatchCallContext(ctx, batch); !errors.Is(err, ErrBadResult) {
+			t.Errorf("expected %q but got: %v", ErrBadResult, err)
+		}
+	})
+
+	t.Run("too-many", func(t *testing.T) {
+		batch := []BatchElem{
+			{Method: "foo"},
+		}
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+		if err := client.BatchCallContext(ctx, batch); !errors.Is(err, ErrBadResult) {
+			t.Errorf("expected %q but got: %v", ErrBadResult, err)
+		}
+	})
 }
 
 func TestClientNotify(t *testing.T) {

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run AvalancheGo e2e tests from the target version against the current state of coreth.
+
+# e.g.,
+# ./scripts/tests.e2e.sh
+# AVALANCHE_VERSION=v1.10.x ./scripts/tests.e2e.sh
+if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+# Coreth root directory
+CORETH_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+# Allow configuring the clone path to point to an existing clone
+AVALANCHEGO_CLONE_PATH="${AVALANCHEGO_CLONE_PATH:-avalanchego}"
+
+# Load the version
+source "$CORETH_PATH"/scripts/versions.sh
+
+# Always return to the coreth path on exit
+function cleanup {
+  cd "${CORETH_PATH}"
+}
+trap cleanup EXIT
+
+echo "checking out target AvalancheGo version ${avalanche_version}"
+if [[ -d "${AVALANCHEGO_CLONE_PATH}" ]]; then
+  echo "updating existing clone"
+  cd "${AVALANCHEGO_CLONE_PATH}"
+  git fetch
+  git checkout -B "${avalanche_version}"
+else
+  echo "creating new clone"
+  git clone -b "${avalanche_version}"\
+      --single-branch https://github.com/ava-labs/avalanchego.git\
+      "${AVALANCHEGO_CLONE_PATH}"
+  cd "${AVALANCHEGO_CLONE_PATH}"
+fi
+
+echo "updating coreth dependency to point to ${CORETH_PATH}"
+go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
+go mod tidy
+
+echo "building avalanchego"
+./scripts/build.sh -r
+
+echo "running AvalancheGo e2e tests"
+./scripts/tests.e2e.sh ./build/avalanchego

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.8'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.10-rc.2'}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.6-rc.4'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.8'}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.10-rc.2'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.10-rc.4'}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.1.8-rc0'} # caminogo version
+avalanche_version=${AVALANCHE_VERSION:-'v1.1.9-rc0'} # caminogo version


### PR DESCRIPTION
## Why this should be merged
This PR contains changes from ava-labs/core-eth between cortina-9 and cortina-10. Its required for upcoming merge of cortina-10 changes to caminogo.

### Introduced changes (summarized):
https://github.com/ava-labs/coreth/releases/tag/v0.12.5

## How this works

### Conflicts

- .github/workflows/ci.yml
- Dockerfile
- plugin/evm/version.go
- scripts/versions.sh

### Fixes

- `plugin/evm/camino_syncervm_test.go` : method createSyncServerAndClientVMsCamino used to replicate the behavior of createSyncServerAndClientVMs in avax's `syncervm_test.go`  with the only change of sunrisephase genesis. I have updated this method to reflect it as updates from avax have been missed in previous merges.

## How this was tested
Automated unit tests