### PR TITLE
Fix state sync version (fork leftover)

### DIFF
--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -40,8 +40,8 @@ const (
 var (
 	StateSyncVersion = &version.Application{
 		Major: 1,
-		Minor: 7,
-		Patch: 13,
+		Minor: 0,
+		Patch: 0,
 	}
 	errEmptyResponse          = errors.New("empty response")
 	errTooManyBlocks          = errors.New("response contains more blocks than requested")


### PR DESCRIPTION
## Why this should be merged
Currently, state-syncing is failing for EVM, because minimal node version which is allowed to be used for state-sync is `1.7.13`, while current node version is just `1.0.0`. Seems that its our left-over from avalanche merge.

## How this works
Replace min version with 1.0.0.

## How this was tested
Manually on camino and columbus networks.