### PR TITLE
columbus fix - state sync

### DIFF
--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -40,8 +40,8 @@ const (
 var (
 	StateSyncVersion = &version.Application{
 		Major: 1,
-		Minor: 7,
-		Patch: 13,
+		Minor: 0,
+		Patch: 0,
 	}
 	errEmptyResponse          = errors.New("empty response")
 	errTooManyBlocks          = errors.New("response contains more blocks than requested")


### PR DESCRIPTION
## Why this should be merged
This solves a bug in state sync which prevented columbus to bootstrap from scratch

## How this works
changing the state sync version fixes the issue

## How this was tested
This was already released as a hotfix v1.0.1 and all columbus validators upgraded their node version
