### PR TITLE
Update chain configs, kyb phase logic

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2184,7 +2184,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/avalanchego@v0.0.0", "-replace", "github.com/ava-labs/avalanchego=github.com/chain4travel/caminogo@v1.1.15-rc1") // Repo root
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/avalanchego@v0.0.0", "-replace", "github.com/ava-labs/avalanchego=github.com/chain4travel/caminogo@v1.1.15-rc3") // Repo root
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)

--- a/eth/ethadmin/camino_ethadmin.go
+++ b/eth/ethadmin/camino_ethadmin.go
@@ -145,8 +145,9 @@ func (a *AdminController) KycVerified(head *types.Header, state admin.StateDB, a
 	if a.cfg.IsSunrisePhase0(head.Time) {
 		// Get the KYC states
 		kycStates := new(big.Int).SetBytes(state.GetState(contractAddr, kycStoragePosition(addr)).Bytes()).Uint64()
-		// Return true if KYC flag is set
-		return (kycStates & VERIFIED) != 0
+		// Return true if KYC or KYB flag is set (KYB after Berlin phase)
+		return !a.cfg.IsBerlin(head.Time) && (kycStates&KYC_VERIFIED) != 0 ||
+			a.cfg.IsBerlin(head.Time) && (kycStates&VERIFIED) != 0
 	}
 	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.1.15-rc2
+replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.1.15-rc3
 
 replace github.com/ava-labs/avalanche-ledger-go => github.com/chain4travel/camino-ledger-go v0.0.13-c4t

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminogo v1.1.15-rc2 h1:QzxhXDa2Ozq/klfslb6SGkzM4BvgPaepyEHa0TsMHjA=
-github.com/chain4travel/caminogo v1.1.15-rc2/go.mod h1:YWdA9uLuJhl52XZidSITIYaSuzJi1xvDCp2IAQIzt+U=
+github.com/chain4travel/caminogo v1.1.15-rc3 h1:UctQ0lswixwnFhAllFYR5deWkMvNEVAq0fS+6bNQoQ8=
+github.com/chain4travel/caminogo v1.1.15-rc3/go.mod h1:YWdA9uLuJhl52XZidSITIYaSuzJi1xvDCp2IAQIzt+U=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/params/camino_config.go
+++ b/params/camino_config.go
@@ -6,7 +6,10 @@ package params
 import (
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/coreth/utils"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // Gas Price
@@ -15,67 +18,32 @@ const (
 	SunrisePhase0BaseFee       uint64 = 200_000_000_000
 )
 
+// Camino ChainIDs
+var (
+	// CaminoChainID ...
+	CaminoChainID = big.NewInt(500)
+	// CaminoChainID ...
+	ColumbusChainID = big.NewInt(501)
+	// KopernikusChainID ...
+	KopernikusChainID = big.NewInt(502)
+)
+
 var (
 	// CaminoChainConfig is the configuration for Camino Main Network
-	CaminoChainConfig = &ChainConfig{
-		ChainID:                         CaminoChainID,
-		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    big.NewInt(0),
-		DAOForkSupport:                  true,
-		EIP150Block:                     big.NewInt(0),
-		EIP155Block:                     big.NewInt(0),
-		EIP158Block:                     big.NewInt(0),
-		ByzantiumBlock:                  big.NewInt(0),
-		ConstantinopleBlock:             big.NewInt(0),
-		PetersburgBlock:                 big.NewInt(0),
-		IstanbulBlock:                   big.NewInt(0),
-		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
-		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
-		BanffBlockTimestamp:             utils.NewUint64(0),
-		// TODO Add Cortina timestamps
-	}
+	CaminoChainConfig = getCaminoChainConfig(constants.CaminoID, CaminoChainID)
 
 	// ColumbusChainConfig is the configuration for Columbus Test Network
-	ColumbusChainConfig = &ChainConfig{
-		ChainID:                         ColumbusChainID,
-		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    big.NewInt(0),
-		DAOForkSupport:                  true,
-		EIP150Block:                     big.NewInt(0),
-		EIP155Block:                     big.NewInt(0),
-		EIP158Block:                     big.NewInt(0),
-		ByzantiumBlock:                  big.NewInt(0),
-		ConstantinopleBlock:             big.NewInt(0),
-		PetersburgBlock:                 big.NewInt(0),
-		IstanbulBlock:                   big.NewInt(0),
-		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
-		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
-		BanffBlockTimestamp:             utils.NewUint64(0),
-		// TODO Add Cortina timestamps
-	}
+	ColumbusChainConfig = getCaminoChainConfig(constants.ColumbusID, ColumbusChainID)
 
 	// KopernikusChainConfig is the configuration for Kopernikus Dev Network
-	KopernikusChainConfig = &ChainConfig{
-		ChainID:                         KopernikusChainID,
+	KopernikusChainConfig = getCaminoChainConfig(constants.KopernikusID, KopernikusChainID)
+
+	TestCaminoChainConfig = &ChainConfig{
+		AvalancheContext:                AvalancheContext{common.Hash{1}},
+		ChainID:                         big.NewInt(1),
 		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    big.NewInt(0),
-		DAOForkSupport:                  true,
+		DAOForkBlock:                    nil,
+		DAOForkSupport:                  false,
 		EIP150Block:                     big.NewInt(0),
 		EIP155Block:                     big.NewInt(0),
 		EIP158Block:                     big.NewInt(0),
@@ -94,9 +62,18 @@ var (
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
 		BanffBlockTimestamp:             utils.NewUint64(0),
-		// TODO Add Cortina timestamps
+		CortinaBlockTimestamp:           utils.NewUint64(0),
+		BerlinBlockTimestamp:            utils.NewUint64(0),
+		DUpgradeBlockTimestamp:          nil,
 	}
 )
+
+func getCaminoChainConfig(networkID uint32, chainID *big.Int) *ChainConfig {
+	chainConfig := getChainConfig(networkID, chainID)
+	chainConfig.SunrisePhase0BlockTimestamp = getUpgradeTime(networkID, version.SunrisePhase0Times)
+	chainConfig.BerlinBlockTimestamp = getUpgradeTime(networkID, version.BerlinPhaseTimes)
+	return chainConfig
+}
 
 // CaminoRules returns the Camino modified rules to support Camino
 // network upgrades
@@ -105,4 +82,16 @@ func (c *ChainConfig) CaminoRules(blockNum *big.Int, blockTimestamp uint64) Rule
 
 	rules.IsSunrisePhase0 = c.IsSunrisePhase0(blockTimestamp)
 	return rules
+}
+
+// IsSunrisePhase0 returns whether [blockTimestamp] represents a block
+// with a timestamp after the Sunrise Phase 0 upgrade time.
+func (c *ChainConfig) IsSunrisePhase0(time uint64) bool {
+	return utils.IsTimestampForked(c.SunrisePhase0BlockTimestamp, time)
+}
+
+// IsBerlin returns whether [time] represents a block
+// with a timestamp after the Berlin upgrade time.
+func (c *ChainConfig) IsBerlin(time uint64) bool {
+	return utils.IsTimestampForked(c.BerlinBlockTimestamp, time)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -42,6 +42,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/coreth/precompile"
 	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,101 +57,19 @@ var (
 	AvalancheFujiChainID = big.NewInt(43113)
 	// AvalancheLocalChainID ...
 	AvalancheLocalChainID = big.NewInt(43112)
-	// CaminoChainID ...
-	CaminoChainID = big.NewInt(500)
-	// CaminoChainID ...
-	ColumbusChainID = big.NewInt(501)
-	// KopernikusChainID ...
-	KopernikusChainID = big.NewInt(502)
 
 	errNonGenesisForkByHeight = errors.New("coreth only supports forking by height at the genesis block")
 )
 
 var (
 	// AvalancheMainnetChainConfig is the configuration for Avalanche Main Network
-	AvalancheMainnetChainConfig = &ChainConfig{
-		ChainID:                         AvalancheMainnetChainID,
-		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    big.NewInt(0),
-		DAOForkSupport:                  true,
-		EIP150Block:                     big.NewInt(0),
-		EIP155Block:                     big.NewInt(0),
-		EIP158Block:                     big.NewInt(0),
-		ByzantiumBlock:                  big.NewInt(0),
-		ConstantinopleBlock:             big.NewInt(0),
-		PetersburgBlock:                 big.NewInt(0),
-		IstanbulBlock:                   big.NewInt(0),
-		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.TimeToNewUint64(time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC)),
-		ApricotPhase2BlockTimestamp:     utils.TimeToNewUint64(time.Date(2021, time.May, 10, 11, 0, 0, 0, time.UTC)),
-		ApricotPhase3BlockTimestamp:     utils.TimeToNewUint64(time.Date(2021, time.August, 24, 14, 0, 0, 0, time.UTC)),
-		ApricotPhase4BlockTimestamp:     utils.TimeToNewUint64(time.Date(2021, time.September, 22, 21, 0, 0, 0, time.UTC)),
-		ApricotPhase5BlockTimestamp:     utils.TimeToNewUint64(time.Date(2021, time.December, 2, 18, 0, 0, 0, time.UTC)),
-		SunrisePhase0BlockTimestamp:     nil,
-		ApricotPhasePre6BlockTimestamp:  utils.TimeToNewUint64(time.Date(2022, time.September, 5, 1, 30, 0, 0, time.UTC)),
-		ApricotPhase6BlockTimestamp:     utils.TimeToNewUint64(time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC)),
-		ApricotPhasePost6BlockTimestamp: utils.TimeToNewUint64(time.Date(2022, time.September, 7, 3, 0, 0, 0, time.UTC)),
-		BanffBlockTimestamp:             utils.TimeToNewUint64(time.Date(2022, time.October, 18, 16, 0, 0, 0, time.UTC)),
-		CortinaBlockTimestamp:           utils.TimeToNewUint64(time.Date(2023, time.April, 25, 15, 0, 0, 0, time.UTC)),
-		// TODO Add DUpgrade timestamp
-	}
+	AvalancheMainnetChainConfig = getChainConfig(constants.MainnetID, AvalancheMainnetChainID)
 
 	// AvalancheFujiChainConfig is the configuration for the Fuji Test Network
-	AvalancheFujiChainConfig = &ChainConfig{
-		ChainID:                     AvalancheFujiChainID,
-		HomesteadBlock:              big.NewInt(0),
-		DAOForkBlock:                big.NewInt(0),
-		DAOForkSupport:              true,
-		EIP150Block:                 big.NewInt(0),
-		EIP155Block:                 big.NewInt(0),
-		EIP158Block:                 big.NewInt(0),
-		ByzantiumBlock:              big.NewInt(0),
-		ConstantinopleBlock:         big.NewInt(0),
-		PetersburgBlock:             big.NewInt(0),
-		IstanbulBlock:               big.NewInt(0),
-		MuirGlacierBlock:            big.NewInt(0),
-		ApricotPhase1BlockTimestamp: utils.TimeToNewUint64(time.Date(2021, time.March, 26, 14, 0, 0, 0, time.UTC)),
-		ApricotPhase2BlockTimestamp: utils.TimeToNewUint64(time.Date(2021, time.May, 5, 14, 0, 0, 0, time.UTC)),
-		ApricotPhase3BlockTimestamp: utils.TimeToNewUint64(time.Date(2021, time.August, 16, 19, 0, 0, 0, time.UTC)),
-		ApricotPhase4BlockTimestamp: utils.TimeToNewUint64(time.Date(2021, time.September, 16, 21, 0, 0, 0, time.UTC)),
-		ApricotPhase5BlockTimestamp: utils.TimeToNewUint64(time.Date(2021, time.November, 24, 15, 0, 0, 0, time.UTC)),
-		// Camino Network Upgrades
-		SunrisePhase0BlockTimestamp:     nil,
-		ApricotPhasePre6BlockTimestamp:  utils.TimeToNewUint64(time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC)),
-		ApricotPhase6BlockTimestamp:     utils.TimeToNewUint64(time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC)),
-		ApricotPhasePost6BlockTimestamp: utils.TimeToNewUint64(time.Date(2022, time.September, 7, 6, 0, 0, 0, time.UTC)),
-		BanffBlockTimestamp:             utils.TimeToNewUint64(time.Date(2022, time.October, 3, 14, 0, 0, 0, time.UTC)),
-		CortinaBlockTimestamp:           utils.TimeToNewUint64(time.Date(2023, time.April, 6, 15, 0, 0, 0, time.UTC)),
-		// TODO Add DUpgrade timestamp
-	}
+	AvalancheFujiChainConfig = getChainConfig(constants.FujiID, AvalancheFujiChainID)
 
 	// AvalancheLocalChainConfig is the configuration for the Avalanche Local Network
-	AvalancheLocalChainConfig = &ChainConfig{
-		ChainID:                         AvalancheLocalChainID,
-		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    big.NewInt(0),
-		DAOForkSupport:                  true,
-		EIP150Block:                     big.NewInt(0),
-		EIP155Block:                     big.NewInt(0),
-		EIP158Block:                     big.NewInt(0),
-		ByzantiumBlock:                  big.NewInt(0),
-		ConstantinopleBlock:             big.NewInt(0),
-		PetersburgBlock:                 big.NewInt(0),
-		IstanbulBlock:                   big.NewInt(0),
-		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
-		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
-		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
-		BanffBlockTimestamp:             utils.NewUint64(0),
-		CortinaBlockTimestamp:           utils.NewUint64(0),
-		DUpgradeBlockTimestamp:          utils.NewUint64(0),
-	}
+	AvalancheLocalChainConfig = getChainConfig(constants.LocalID, AvalancheLocalChainID)
 
 	TestChainConfig = &ChainConfig{
 		AvalancheContext:                AvalancheContext{common.Hash{1}},
@@ -170,35 +90,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
-		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
-		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
-		BanffBlockTimestamp:             utils.NewUint64(0),
-		CortinaBlockTimestamp:           utils.NewUint64(0),
-		DUpgradeBlockTimestamp:          utils.NewUint64(0),
-	}
-
-	TestCaminoChainConfig = &ChainConfig{
-		AvalancheContext:                AvalancheContext{common.Hash{1}},
-		ChainID:                         big.NewInt(1),
-		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    nil,
-		DAOForkSupport:                  false,
-		EIP150Block:                     big.NewInt(0),
-		EIP155Block:                     big.NewInt(0),
-		EIP158Block:                     big.NewInt(0),
-		ByzantiumBlock:                  big.NewInt(0),
-		ConstantinopleBlock:             big.NewInt(0),
-		PetersburgBlock:                 big.NewInt(0),
-		IstanbulBlock:                   big.NewInt(0),
-		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
@@ -226,7 +117,6 @@ var (
 		ApricotPhase3BlockTimestamp:     nil,
 		ApricotPhase4BlockTimestamp:     nil,
 		ApricotPhase5BlockTimestamp:     nil,
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -254,7 +144,6 @@ var (
 		ApricotPhase3BlockTimestamp:     nil,
 		ApricotPhase4BlockTimestamp:     nil,
 		ApricotPhase5BlockTimestamp:     nil,
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -282,7 +171,6 @@ var (
 		ApricotPhase3BlockTimestamp:     nil,
 		ApricotPhase4BlockTimestamp:     nil,
 		ApricotPhase5BlockTimestamp:     nil,
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -310,7 +198,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     nil,
 		ApricotPhase5BlockTimestamp:     nil,
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -338,7 +225,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     nil,
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -366,7 +252,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  nil,
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -394,7 +279,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     nil,
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -422,7 +306,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: nil,
@@ -450,7 +333,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
@@ -478,7 +360,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
@@ -506,7 +387,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
@@ -534,7 +414,6 @@ var (
 		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     nil,
 		ApricotPhasePre6BlockTimestamp:  utils.NewUint64(0),
 		ApricotPhase6BlockTimestamp:     utils.NewUint64(0),
 		ApricotPhasePost6BlockTimestamp: utils.NewUint64(0),
@@ -542,12 +421,15 @@ var (
 		CortinaBlockTimestamp:           utils.NewUint64(0),
 	}
 
-	TestSunrisePhase0Config = &ChainConfig{
-		AvalancheContext:                AvalancheContext{common.Hash{1}},
-		ChainID:                         big.NewInt(1),
+	TestRules = TestChainConfig.AvalancheRules(new(big.Int), 0)
+)
+
+func getChainConfig(networkID uint32, chainID *big.Int) *ChainConfig {
+	return &ChainConfig{
+		ChainID:                         chainID,
 		HomesteadBlock:                  big.NewInt(0),
-		DAOForkBlock:                    nil,
-		DAOForkSupport:                  false,
+		DAOForkBlock:                    big.NewInt(0),
+		DAOForkSupport:                  true,
 		EIP150Block:                     big.NewInt(0),
 		EIP155Block:                     big.NewInt(0),
 		EIP158Block:                     big.NewInt(0),
@@ -556,21 +438,28 @@ var (
 		PetersburgBlock:                 big.NewInt(0),
 		IstanbulBlock:                   big.NewInt(0),
 		MuirGlacierBlock:                big.NewInt(0),
-		ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase3BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase4BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhase5BlockTimestamp:     utils.NewUint64(0),
-		SunrisePhase0BlockTimestamp:     utils.NewUint64(0),
-		ApricotPhasePre6BlockTimestamp:  nil,
-		ApricotPhase6BlockTimestamp:     nil,
-		ApricotPhasePost6BlockTimestamp: nil,
-		BanffBlockTimestamp:             nil,
-		CortinaBlockTimestamp:           nil,
-		DUpgradeBlockTimestamp:          nil,
+		ApricotPhase1BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase1Times),
+		ApricotPhase2BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase2Times),
+		ApricotPhase3BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase3Times),
+		ApricotPhase4BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase4Times),
+		ApricotPhase5BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase5Times),
+		ApricotPhasePre6BlockTimestamp:  getUpgradeTime(networkID, version.ApricotPhasePre6Times),
+		ApricotPhase6BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase6Times),
+		ApricotPhasePost6BlockTimestamp: getUpgradeTime(networkID, version.ApricotPhasePost6Times),
+		BanffBlockTimestamp:             getUpgradeTime(networkID, version.BanffTimes),
+		CortinaBlockTimestamp:           getUpgradeTime(networkID, version.CortinaTimes),
+		DUpgradeBlockTimestamp:          getUpgradeTime(networkID, version.DTimes),
 	}
-	TestRules = TestChainConfig.AvalancheRules(new(big.Int), 0)
-)
+}
+
+func getUpgradeTime(networkID uint32, upgradeTimes map[uint32]time.Time) *uint64 {
+	if upgradeTime, ok := upgradeTimes[networkID]; ok {
+		return utils.TimeToNewUint64(upgradeTime)
+	}
+	// If the upgrade time isn't specified, default being enabled in the
+	// genesis.
+	return utils.NewUint64(0)
+}
 
 // ChainConfig is the core config which determines the blockchain settings.
 //
@@ -622,12 +511,16 @@ type ChainConfig struct {
 	BanffBlockTimestamp *uint64 `json:"banffBlockTimestamp,omitempty"`
 	// Cortina increases the block gas limit to 15M. (nil = no fork, 0 = already activated)
 	CortinaBlockTimestamp *uint64 `json:"cortinaBlockTimestamp,omitempty"`
+	// Berlin does nothing
+	BerlinBlockTimestamp *uint64 `json:"berlinBlockTimestamp,omitempty"`
 	// DUpgrade activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
 	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
 	// Note: EIP-4895 is excluded since withdrawals are not relevant to the Avalanche C-Chain or Subnets running the EVM.
 	DUpgradeBlockTimestamp *uint64 `json:"dUpgradeBlockTimestamp,omitempty"`
 	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
 	CancunTime *uint64 `json:"cancunTime,omitempty"`
+
+	// Athens phase does nothing for c-chain, so it is not included in the ChainConfig.
 }
 
 // AvalancheContext provides Avalanche specific context directly into the EVM.
@@ -795,14 +688,6 @@ func (c *ChainConfig) IsCortina(time uint64) bool {
 // with a timestamp after the DUpgrade upgrade time.
 func (c *ChainConfig) IsDUpgrade(time uint64) bool {
 	return utils.IsTimestampForked(c.DUpgradeBlockTimestamp, time)
-}
-
-// Camino Upgrades:
-
-// IsSunrisePhase0 returns whether [blockTimestamp] represents a block
-// with a timestamp after the Sunrise Phase 0 upgrade time.
-func (c *ChainConfig) IsSunrisePhase0(time uint64) bool {
-	return utils.IsTimestampForked(c.SunrisePhase0BlockTimestamp, time)
 }
 
 // IsCancun returns whether [time] represents a block


### PR DESCRIPTION
PR adds phase logic to KYB check, so it will only work if Berlin phase is active.
PR also updates chain configs with Berlin timestamp field and improves chain configs code with some funcs from latest avax cortina, which allows more simple use of timestamp constants from caminogo instead of duplicating them in caminoethvm.