### PR TITLE
Merge c4t to dev

### DIFF
--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -40,8 +40,8 @@ const (
 var (
 	StateSyncVersion = &version.Application{
 		Major: 1,
-		Minor: 7,
-		Patch: 13,
+		Minor: 0,
+		Patch: 0,
 	}
 	errEmptyResponse          = errors.New("empty response")
 	errTooManyBlocks          = errors.New("response contains more blocks than requested")


### PR DESCRIPTION
## Why this should be merged
Merging 1.0.1 hotfix that is present only in c4t branch.
Hotfix solves a bug in state sync which was preventing nodes from use state syncing instead of bootstrapping.
## How this works
Changing the state sync version fixes the issue.
## How this was tested
This was already released as a hotfix v1.0.1 and all columbus validators upgraded their node version
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminoethvm/pull/109