### PR TITLE
Update chain configs, kyb phase logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |
@@ -75,7 +75,7 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |
@@ -114,7 +114,7 @@ jobs:
         path: caminogo
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: change caminogo dep
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.caminogoBranch != '' }}
       run: |

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2161,7 +2161,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/avalanchego@v0.0.0", "-replace", "github.com/ava-labs/avalanchego=github.com/chain4travel/caminogo@v1.0.0-rc1") // Repo root
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/avalanchego@v0.0.0", "-replace", "github.com/ava-labs/avalanchego=github.com/chain4travel/caminogo@v1.1.0-rc2") // Repo root
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)

--- a/eth/ethadmin/camino_ethadmin.go
+++ b/eth/ethadmin/camino_ethadmin.go
@@ -142,11 +142,13 @@ func (a *AdminController) GetFixedBaseFee(head *types.Header, state admin.StateD
 }
 
 func (a *AdminController) KycVerified(head *types.Header, state admin.StateDB, addr common.Address) bool {
-	if a.cfg.IsSunrisePhase0(big.NewInt(int64(head.Time))) {
+	timestamp := big.NewInt(int64(head.Time))
+	if a.cfg.IsSunrisePhase0(timestamp) {
 		// Get the KYC states
 		kycStates := new(big.Int).SetBytes(state.GetState(contractAddr, kycStoragePosition(addr)).Bytes()).Uint64()
-		// Return true if KYC flag is set
-		return (kycStates & VERIFIED) != 0
+		// Return true if KYC or KYB flag is set (KYB after Berlin phase)
+		return !a.cfg.IsBerlin(timestamp) && (kycStates&KYC_VERIFIED) != 0 ||
+			a.cfg.IsBerlin(timestamp) && (kycStates&VERIFIED) != 0
 	}
 	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect
@@ -125,6 +126,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.0.0-rc1
+replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v1.1.0-rc2
 
 replace github.com/ava-labs/avalanche-ledger-go => github.com/chain4travel/camino-ledger-go v0.0.13-c4t

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VictoriaMetrics/fastcache v1.10.0 h1:5hDJnLsKLpnUEToub7ETuRu8RCkb40woBZAUiKonXzY=
 github.com/VictoriaMetrics/fastcache v1.10.0/go.mod h1:tjiYeEfYXCqacuvYw/7UoDIeJaNxq6132xHICNP77w8=
@@ -100,8 +102,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminogo v1.0.0-rc1 h1:mWNp3d4/Wm1jwpsuSOz9EQRCyTL+qspZYbW7G8VBa/8=
-github.com/chain4travel/caminogo v1.0.0-rc1/go.mod h1:q1rl0Dh8bmdUw9KKLEYxlJqGFPlbvTPPTAJLV/JgoR4=
+github.com/chain4travel/caminogo v1.1.0-rc2 h1:/HmFioe8fUL0eMGwz2CEvQrcV2CETs/Swhomzqg2qeY=
+github.com/chain4travel/caminogo v1.1.0-rc2/go.mod h1:ERqKUtzxe5H8G2wCNRZxQja/FFIkxbc1jKoo17neiWc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/params/camino_config.go
+++ b/params/camino_config.go
@@ -6,6 +6,9 @@ package params
 import (
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -15,91 +18,36 @@ const (
 	SunrisePhase0BaseFee       uint64 = 200_000_000_000
 )
 
+// Camino ChainIDs
+var (
+	// CaminoChainID ...
+	CaminoChainID = big.NewInt(500)
+	// CaminoChainID ...
+	ColumbusChainID = big.NewInt(501)
+	// KopernikusChainID ...
+	KopernikusChainID = big.NewInt(502)
+)
+
 var (
 	// CaminoChainConfig is the configuration for Camino Main Network
-	CaminoChainConfig = &ChainConfig{
-		ChainID:                         CaminoChainID,
-		HomesteadBlock:                  common.Big0,
-		DAOForkBlock:                    common.Big0,
-		DAOForkSupport:                  true,
-		EIP150Block:                     common.Big0,
-		EIP150Hash:                      common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:                     common.Big0,
-		EIP158Block:                     common.Big0,
-		ByzantiumBlock:                  common.Big0,
-		ConstantinopleBlock:             common.Big0,
-		PetersburgBlock:                 common.Big0,
-		IstanbulBlock:                   common.Big0,
-		MuirGlacierBlock:                common.Big0,
-		ApricotPhase1BlockTimestamp:     common.Big0,
-		ApricotPhase2BlockTimestamp:     common.Big0,
-		ApricotPhase3BlockTimestamp:     common.Big0,
-		ApricotPhase4BlockTimestamp:     common.Big0,
-		ApricotPhase5BlockTimestamp:     common.Big0,
-		SunrisePhase0BlockTimestamp:     common.Big0,
-		ApricotPhasePre6BlockTimestamp:  common.Big0,
-		ApricotPhase6BlockTimestamp:     common.Big0,
-		ApricotPhasePost6BlockTimestamp: common.Big0,
-		BanffBlockTimestamp:             common.Big0,
-		// TODO Add Cortina timestamps
-	}
+	CaminoChainConfig = getCaminoChainConfig(constants.CaminoID, CaminoChainID)
 
 	// ColumbusChainConfig is the configuration for Columbus Test Network
-	ColumbusChainConfig = &ChainConfig{
-		ChainID:                         ColumbusChainID,
-		HomesteadBlock:                  common.Big0,
-		DAOForkBlock:                    common.Big0,
-		DAOForkSupport:                  true,
-		EIP150Block:                     common.Big0,
-		EIP150Hash:                      common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:                     common.Big0,
-		EIP158Block:                     common.Big0,
-		ByzantiumBlock:                  common.Big0,
-		ConstantinopleBlock:             common.Big0,
-		PetersburgBlock:                 common.Big0,
-		IstanbulBlock:                   common.Big0,
-		MuirGlacierBlock:                common.Big0,
-		ApricotPhase1BlockTimestamp:     common.Big0,
-		ApricotPhase2BlockTimestamp:     common.Big0,
-		ApricotPhase3BlockTimestamp:     common.Big0,
-		ApricotPhase4BlockTimestamp:     common.Big0,
-		ApricotPhase5BlockTimestamp:     common.Big0,
-		SunrisePhase0BlockTimestamp:     common.Big0,
-		ApricotPhasePre6BlockTimestamp:  common.Big0,
-		ApricotPhase6BlockTimestamp:     common.Big0,
-		ApricotPhasePost6BlockTimestamp: common.Big0,
-		BanffBlockTimestamp:             common.Big0,
-		// TODO Add Cortina timestamps
-	}
+	ColumbusChainConfig = getCaminoChainConfig(constants.ColumbusID, ColumbusChainID)
 
 	// KopernikusChainConfig is the configuration for Kopernikus Dev Network
-	KopernikusChainConfig = &ChainConfig{
-		ChainID:                         KopernikusChainID,
-		HomesteadBlock:                  common.Big0,
-		DAOForkBlock:                    common.Big0,
-		DAOForkSupport:                  true,
-		EIP150Block:                     common.Big0,
-		EIP150Hash:                      common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:                     common.Big0,
-		EIP158Block:                     common.Big0,
-		ByzantiumBlock:                  common.Big0,
-		ConstantinopleBlock:             common.Big0,
-		PetersburgBlock:                 common.Big0,
-		IstanbulBlock:                   common.Big0,
-		MuirGlacierBlock:                common.Big0,
-		ApricotPhase1BlockTimestamp:     common.Big0,
-		ApricotPhase2BlockTimestamp:     common.Big0,
-		ApricotPhase3BlockTimestamp:     common.Big0,
-		ApricotPhase4BlockTimestamp:     common.Big0,
-		ApricotPhase5BlockTimestamp:     common.Big0,
-		SunrisePhase0BlockTimestamp:     common.Big0,
-		ApricotPhasePre6BlockTimestamp:  common.Big0,
-		ApricotPhase6BlockTimestamp:     common.Big0,
-		ApricotPhasePost6BlockTimestamp: common.Big0,
-		BanffBlockTimestamp:             common.Big0,
-		// TODO Add Cortina timestamps
-	}
+	KopernikusChainConfig = getCaminoChainConfig(constants.KopernikusID, KopernikusChainID)
+
+	TestCaminoChainConfig = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)}
 )
+
+func getCaminoChainConfig(networkID uint32, chainID *big.Int) *ChainConfig {
+	chainConfig := getChainConfig(networkID, chainID)
+	chainConfig.EIP150Hash = common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0")
+	chainConfig.SunrisePhase0BlockTimestamp = getUpgradeTime(networkID, version.SunrisePhase0Times)
+	chainConfig.BerlinBlockTimestamp = getUpgradeTime(networkID, version.BerlinPhaseTimes)
+	return chainConfig
+}
 
 // CaminoRules returns the Camino modified rules to support Camino
 // network upgrades
@@ -108,4 +56,16 @@ func (c *ChainConfig) CaminoRules(blockNum, blockTimestamp *big.Int) Rules {
 
 	rules.IsSunrisePhase0 = c.IsSunrisePhase0(blockTimestamp)
 	return rules
+}
+
+// IsSunrisePhase0 returns whether [blockTimestamp] represents a block
+// with a timestamp after the Sunrise Phase 0 upgrade time.
+func (c *ChainConfig) IsSunrisePhase0(time *big.Int) bool {
+	return utils.IsForked(c.SunrisePhase0BlockTimestamp, time)
+}
+
+// IsBerlin returns whether [time] represents a block
+// with a timestamp after the Berlin upgrade time.
+func (c *ChainConfig) IsBerlin(time *big.Int) bool {
+	return utils.IsForked(c.BerlinBlockTimestamp, time)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -42,6 +42,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/coreth/precompile"
 	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,12 +56,6 @@ var (
 	AvalancheFujiChainID = big.NewInt(43113)
 	// AvalancheLocalChainID ...
 	AvalancheLocalChainID = big.NewInt(43112)
-	// CaminoChainID ...
-	CaminoChainID = big.NewInt(500)
-	// CaminoChainID ...
-	ColumbusChainID = big.NewInt(501)
-	// KopernikusChainID ...
-	KopernikusChainID = big.NewInt(502)
 
 	errNonGenesisForkByHeight = errors.New("coreth only supports forking by height at the genesis block")
 )
@@ -153,20 +148,18 @@ var (
 		CortinaBlockTimestamp:           big.NewInt(0),
 	}
 
-	TestChainConfig             = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)}
-	TestCaminoChainConfig       = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)}
-	TestLaunchConfig            = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhase1Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhase2Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhase3Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhase4Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhase5Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil}
-	TestApricotPhasePre6Config  = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, nil, nil, nil, nil}
-	TestApricotPhase6Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), nil, nil, nil, nil}
-	TestApricotPhasePost6Config = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil}
-	TestBanffChainConfig        = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil}
-	TestCortinaChainConfig      = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil}
-	TestSunrisePhase0Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil}
+	TestChainConfig             = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil}
+	TestLaunchConfig            = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhase1Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhase2Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhase3Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhase4Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhase5Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil}
+	TestApricotPhasePre6Config  = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, nil, nil, nil, nil, nil}
+	TestApricotPhase6Config     = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil}
+	TestApricotPhasePost6Config = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil}
+	TestBanffChainConfig        = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil}
+	TestCortinaChainConfig      = &ChainConfig{AvalancheContext{common.Hash{1}}, big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil}
 	TestRules                   = TestChainConfig.AvalancheRules(new(big.Int), new(big.Int))
 )
 
@@ -210,7 +203,7 @@ type ChainConfig struct {
 	// Apricot Phase 5 introduces a batch of atomic transactions with a maximum atomic gas limit per block. (nil = no fork, 0 = already activated)
 	ApricotPhase5BlockTimestamp *big.Int `json:"apricotPhase5BlockTimestamp,omitempty"`
 	// Camino Network Upgrades
-	// Sunrise Phase 0 introduces fixed 50nCAM BaseFee
+	// Sunrise Phase 0 introduces fixed 50nCAM BaseFee. (nil = no fork, 0 = already activated)
 	SunrisePhase0BlockTimestamp *big.Int `json:"sunrisePhase0BlockTimestamp,omitempty"`
 	// Apricot Phase Pre-6 deprecates the NativeAssetCall precompile (soft). (nil = no fork, 0 = already activated)
 	ApricotPhasePre6BlockTimestamp *big.Int `json:"apricotPhasePre6BlockTimestamp,omitempty"`
@@ -222,13 +215,53 @@ type ChainConfig struct {
 	BanffBlockTimestamp *big.Int `json:"banffBlockTimestamp,omitempty"`
 	// Cortina increases the block gas limit to 15M. (nil = no fork, 0 = already activated)
 	CortinaBlockTimestamp *big.Int `json:"cortinaBlockTimestamp,omitempty"`
+	// Berlin allows KYB verified addresses to create contracts. (nil = no fork, 0 = already activated)
+	BerlinBlockTimestamp *big.Int `json:"berlinBlockTimestamp,omitempty"`
 	// DUpgrade activates the Shanghai upgrade from Ethereum. (nil = no fork, 0 = already activated)
 	DUpgradeBlockTimestamp *big.Int `json:"dUpgradeBlockTimestamp,omitempty"`
+
+	// Athens phase does nothing for c-chain, so it is not included in the ChainConfig.
 }
 
 // AvalancheContext provides Avalanche specific context directly into the EVM.
 type AvalancheContext struct {
 	BlockchainID common.Hash
+}
+
+func getChainConfig(networkID uint32, chainID *big.Int) *ChainConfig {
+	return &ChainConfig{
+		ChainID:                         chainID,
+		HomesteadBlock:                  big.NewInt(0),
+		DAOForkBlock:                    big.NewInt(0),
+		DAOForkSupport:                  true,
+		EIP150Block:                     big.NewInt(0),
+		EIP155Block:                     big.NewInt(0),
+		EIP158Block:                     big.NewInt(0),
+		ByzantiumBlock:                  big.NewInt(0),
+		ConstantinopleBlock:             big.NewInt(0),
+		PetersburgBlock:                 big.NewInt(0),
+		IstanbulBlock:                   big.NewInt(0),
+		MuirGlacierBlock:                big.NewInt(0),
+		ApricotPhase1BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase1Times),
+		ApricotPhase2BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase2Times),
+		ApricotPhase3BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase3Times),
+		ApricotPhase4BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase4Times),
+		ApricotPhase5BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase5Times),
+		ApricotPhasePre6BlockTimestamp:  getUpgradeTime(networkID, version.ApricotPhasePre6Times),
+		ApricotPhase6BlockTimestamp:     getUpgradeTime(networkID, version.ApricotPhase6Times),
+		ApricotPhasePost6BlockTimestamp: getUpgradeTime(networkID, version.ApricotPhasePost6Times),
+		BanffBlockTimestamp:             getUpgradeTime(networkID, version.BanffTimes),
+		CortinaBlockTimestamp:           getUpgradeTime(networkID, version.CortinaTimes),
+	}
+}
+
+func getUpgradeTime(networkID uint32, upgradeTimes map[uint32]time.Time) *big.Int {
+	if upgradeTime, ok := upgradeTimes[networkID]; ok {
+		return big.NewInt(upgradeTime.Unix())
+	}
+	// If the upgrade time isn't specified, default being enabled in the
+	// genesis.
+	return big.NewInt(0)
 }
 
 // String implements the fmt.Stringer interface.
@@ -390,14 +423,6 @@ func (c *ChainConfig) IsCortina(blockTimestamp *big.Int) bool {
 // with a timestamp after the DUpgrade upgrade time.
 func (c *ChainConfig) IsDUpgrade(blockTimestamp *big.Int) bool {
 	return utils.IsForked(c.DUpgradeBlockTimestamp, blockTimestamp)
-}
-
-// Camino Upgrades:
-
-// IsSunrisePhase0 returns whether [blockTimestamp] represents a block
-// with a timestamp after the Sunrise Phase 0 upgrade time.
-func (c *ChainConfig) IsSunrisePhase0(blockTimestamp *big.Int) bool {
-	return utils.IsForked(c.SunrisePhase0BlockTimestamp, blockTimestamp)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -4,7 +4,7 @@
 GOPATH="$(go env GOPATH)"
 
 # Set binary location
-binary_path=${CAMINOETHVM_BINARY_PATH:-"$GOPATH/src/github.com/chain4travel/camino-node/build/plugins/evm"}
+binary_path=${CAMINOETHVM_BINARY_PATH:-"$GOPATH/src/github.com/chain4travel/caminogo/build/plugins/evm"}
 
 # Avalabs docker hub
 dockerhub_repo="c4tplatform/caminoethvm"
@@ -23,7 +23,7 @@ module=$(grep caminogo $CAMINOETHVM_PATH/go.mod)
 # trim leading
 module="${module#"${module%%[![:space:]]*}"}"
 t=(${module//\ / })
-caminogo_tag=${t[1]}
+caminogo_tag=${t[4]}
 
 build_image_id=${BUILD_IMAGE_ID:-"$caminogo_tag-$caminoethvm_short_commit"}
 


### PR DESCRIPTION
PR adds phase logic to KYB check, so it will only work if Berlin phase is active.
PR also updates chain configs with Berlin timestamp field and improves chain configs code with some funcs from latest avax cortina, which allows more simple use of timestamp constants from caminogo instead of duplicating them in caminoethvm.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminoethvm/pull/108