### PR TITLE
Add missing cortina gas limit check to camino block verification

### DIFF
--- a/plugin/evm/camino_block_verification.go
+++ b/plugin/evm/camino_block_verification.go
@@ -56,11 +56,20 @@ func (bv blockValidatorCamino) SyntacticVerify(b *Block, rules params.Rules) err
 			ethHeader.Nonce.Uint64(), errInvalidNonce,
 		)
 	}
-	if ethHeader.GasLimit != params.ApricotPhase1GasLimit {
-		return fmt.Errorf(
-			"expected gas limit to be %d in apricot phase 1 but got %d",
-			params.ApricotPhase1GasLimit, ethHeader.GasLimit,
-		)
+	if rules.IsCortina {
+		if ethHeader.GasLimit != params.CortinaGasLimit {
+			return fmt.Errorf(
+				"expected gas limit to be %d after cortina but got %d",
+				params.CortinaGasLimit, ethHeader.GasLimit,
+			)
+		}
+	} else if rules.IsApricotPhase1 {
+		if ethHeader.GasLimit != params.ApricotPhase1GasLimit {
+			return fmt.Errorf(
+				"expected gas limit to be %d after apricot phase 1 but got %d",
+				params.ApricotPhase1GasLimit, ethHeader.GasLimit,
+			)
+		}
 	}
 	if ethHeader.MixDigest != (common.Hash{}) {
 		return fmt.Errorf("invalid mix digest: %v", ethHeader.MixDigest)


### PR DESCRIPTION
Cortina 0 changes gas limit in `plugin/evm/block_verification.go`, but it wasn't changed in `plugin/evm/camino_block_verification.go`. This PR fixes that.