### PR TITLE
Fix state-syncing for large blocks

### DIFF
--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	Version        = uint16(0)
-	maxMessageSize = 1 * units.MiB
+	maxMessageSize = 2*units.MiB - 64*units.KiB // Subtract 64 KiB from p2p network cap to leave room for encoding overhead from AvalancheGo
 )
 
 var (

--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Codec = codec.NewManager(maxMessageSize)
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs := wrappers.Errs{}
 	errs.Add(
@@ -49,7 +49,7 @@ func init() {
 	}
 
 	CrossChainCodec = codec.NewManager(maxMessageSize)
-	ccc := linearcodec.NewDefault()
+	ccc := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs = wrappers.Errs{}
 	errs.Add(

--- a/plugin/evm/message/message_test.go
+++ b/plugin/evm/message/message_test.go
@@ -63,7 +63,7 @@ func TestEthTxsTooLarge(t *testing.T) {
 	assert := assert.New(t)
 
 	builtMsg := EthTxsGossip{
-		Txs: utils.RandomBytes(1024 * units.KiB),
+		Txs: utils.RandomBytes(maxMessageSize),
 	}
 	_, err := BuildGossipMessage(Codec, builtMsg)
 	assert.Error(err)

--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -351,7 +351,7 @@ func (c *client) get(ctx context.Context, request message.Request, parseFn parse
 			responseIntf, numElements, err = parseFn(c.codec, request, response)
 			if err != nil {
 				lastErr = err
-				log.Info("could not validate response, retrying", "nodeID", nodeID, "attempt", attempt, "request", request, "err", err)
+				log.Debug("could not validate response, retrying", "nodeID", nodeID, "attempt", attempt, "request", request, "err", err)
 				c.networkClient.TrackBandwidth(nodeID, 0)
 				metric.IncFailed()
 				metric.IncInvalidResponse()

--- a/sync/handlers/block_request_test.go
+++ b/sync/handlers/block_request_test.go
@@ -167,7 +167,7 @@ func TestBlockRequestHandlerLargeBlocks(t *testing.T) {
 	blocks, _, err := core.GenerateChain(gspec.Config, genesis, engine, memdb, 96, 0, func(i int, b *core.BlockGen) {
 		var data []byte
 		switch {
-		case i < 32:
+		case i <= 32:
 			data = make([]byte, units.MiB)
 		default:
 			data = make([]byte, units.MiB/16)


### PR DESCRIPTION
## Why this should be merged

When node is doing state syncing, it will get state summary and then will try to get next 256 blocks after state summary using state syncing client, which uses its own codec. This codec is failing to marshal block request responses that contain large blocks (like 714 transfer transactions) because of max slice size in codec.

PR fixes that issue.

## How this works

PR applies 3 PR from avalanche, that resolve the issue:
- https://github.com/ava-labs/coreth/pull/402
- https://github.com/ava-labs/coreth/pull/403
- https://github.com/ava-labs/coreth/pull/423

Essentially, it bumps max slice size for codec used by state syncing block requests.

## How this was tested
1) Configured c chain to do state syncing when there is more than 300 blocks instead of default `defaultStateSyncMinBlocks`
2) Spinned up local network of 5 nodes, made them produce 20_000 blocks, where blocks are mostly blocks of max size (714 txs) with no more than 250 blocks of lesser size between them, so at least one big block will always fit into 256 blocks of state syncing.
3) Added another node and made sure that it failed to state sync, because other nodes failed to marshal block request response with big blocks.
4) Restarted nodes with applied fix, confirmed that state syncing worked this time.
